### PR TITLE
Add ability to wrap variable names in \text{}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,12 @@ Authors@R: c(
            family  = 'Sidi',
            role    =  'ctb',           
            email   = 'yonis@metrumrg.com',
-           comment = c(ORCID = "https://orcid.org/0000-0002-4222-1819")
-           )
+           comment = c(ORCID = "https://orcid.org/0000-0002-4222-1819")),
+    person(given = "Andrew",
+           family = "Heiss",
+           role = c("ctb"),
+           email = "andrew@andrewheiss.com",
+           comment = c(ORCID = "https://orcid.org/0000-0002-3948-3914"))
     )
 Description: The goal of equatiomatic is to reduce the pain associated with
              writing LaTex formulas from fitted models. The primary function of

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,13 +6,24 @@ detect_categorical <- function(formula_rhs, full_rhs) {
   logical(1))
 }
 
-add_dummy_subscripts <- function(cat_vars, full_rhs) {
+add_dummy_subscripts <- function(cat_vars, full_rhs, use_text = FALSE) {
   vars <- lapply(cat_vars, function(x) full_rhs[grepl(x, full_rhs)])
   levs <- Map(function(.x, .y) gsub(.x, "", .y),
               .x = cat_vars,
               .y = vars)
-  cats <- Map(function(var_name, lev) paste0(var_name, "_{", lev, "}"),
-              var_name = names(levs),
-              lev      = levs)
+  if (use_text) {
+    cats <- Map(function(var_name, lev) paste0(wrap_text(var_name), "_{", wrap_text(lev), "}"),
+                var_name = names(levs),
+                lev      = levs)
+  } else {
+    cats <- Map(function(var_name, lev) paste0(var_name, "_{", lev, "}"),
+                var_name = names(levs),
+                lev      = levs)
+  }
+
   cats
+}
+
+wrap_text <- function(x) {
+  paste0("\\text{", x, "}")
 }

--- a/man/equatiomatic-package.Rd
+++ b/man/equatiomatic-package.Rd
@@ -22,6 +22,7 @@ Authors:
 Other contributors:
 \itemize{
   \item Jonathan Sidi \email{yonis@metrumrg.com} (https://orcid.org/0000-0002-4222-1819) [contributor]
+  \item Andrew Heiss \email{andrew@andrewheiss.com} (https://orcid.org/0000-0002-3948-3914) [contributor]
 }
 
 }

--- a/man/extract_eq_lm.Rd
+++ b/man/extract_eq_lm.Rd
@@ -4,13 +4,16 @@
 \alias{extract_eq_lm}
 \title{Latex code for `lm` models}
 \usage{
-extract_eq_lm(model, preview = FALSE)
+extract_eq_lm(model, preview = FALSE, use_text = FALSE)
 }
 \arguments{
 \item{model}{A fitted `lm` model}
 
 \item{preview}{Logical, defaults to \code{FALSE}. Should the equation be
 previewed in the viewer pane?}
+
+\item{use_text}{Logical, defaults to \code{FALSE}. Should the variable names
+be wrapped in the \code{\\text{}} command}
 }
 \description{
 Uses the variable names supplied to \link[stats]{lm} to produce a LaTeX
@@ -41,4 +44,11 @@ extract_eq_lm(mod4)
 
 # Or preview the equation
 extract_eq_lm(mod4, preview = TRUE)
+
+# Use \\text{}
+# Simple model
+extract_eq_lm(mod1, use_text = TRUE)
+
+# Categorical variables
+extract_eq_lm(mod3, use_text = TRUE)
 }


### PR DESCRIPTION
I like putting non-math text in `\text{}` commands so things don't get overly italicized. I added an optional `use_text` argument to `extract_eq_lm()` that wraps variable names with `\text{}`:

``` r
# Simple model
mod1 <- lm(mpg ~ cyl + disp, mtcars)
extract_eq_lm(mod1, use_text = TRUE)
#> $$
#>  \text{mpg} = \alpha + \beta_{1}(\text{cyl}) + \beta_{2}(\text{disp}) + \epsilon 
#> $$
```

![example1](https://user-images.githubusercontent.com/73663/58372454-a2c06980-7eda-11e9-89c8-abfa7411e18d.png)

It works with categorical variables too:

``` r
# Categorical variables
mod3 <- lm(Sepal.Length ~ Sepal.Width + Species, iris)
extract_eq_lm(mod3, use_text = TRUE)
#> $$
#>  \text{Sepal.Length} = \alpha + \beta_{1}(\text{Sepal.Width}) + \beta_{2}(\text{Species}_{\text{versicolor}}) + \beta_{3}(\text{Species}_{\text{virginica}}) + \epsilon 
#> $$
```

![long](https://user-images.githubusercontent.com/73663/58378574-6bda6a00-7f53-11e9-8cea-56609147b7dd.png)
