### PR TITLE
Add ability to wrap equation in aligned environment (part of #8)

### DIFF
--- a/R/eq_lm.R
+++ b/R/eq_lm.R
@@ -5,9 +5,17 @@
 #'
 #' @param model A fitted `lm` model
 #' @param preview Logical, defaults to \code{FALSE}. Should the equation be
-#' previewed in the viewer pane?
+#'   previewed in the viewer pane?
 #' @param use_text Logical, defaults to \code{FALSE}. Should the variable names
-#' be wrapped in the \code{\\text{}} command
+#'   be wrapped in the \code{\\text{}} command?
+#' @param aligned Logical, defaults to \code{FALSE}. Should the equation be
+#'   inserted in a special \code{aligned} TeX environment and automatically
+#'   wrapped to a specific width?
+#' @param width Integer, defaults to 80. The suggested of characters per line in
+#'   the split equation. Used only when \code{aligned} is \code{TRUE}
+#' @param align_env TeX environment to wrap around equation. Must be one of
+#'   \code{aligned}, \code{aligned*}, \code{align}, or \code{align*}. Defaults
+#'   to \code{aligned}
 #'
 #' @export
 #' @examples
@@ -42,8 +50,20 @@
 #'
 #' # Categorical variables
 #' extract_eq_lm(mod3, use_text = TRUE)
+#'
+#' # Wrap equations in an "aligned" environment
+#' extract_eq_lm(mod2, aligned = TRUE)
+#'
+#' # Wider equation wrapping
+#' extract_eq_lm(mod2, aligned = TRUE, width = 100)
 
-extract_eq_lm <- function(model, preview = FALSE, use_text = FALSE) {
+extract_eq_lm <- function(model, preview = FALSE, use_text = FALSE,
+                          aligned = FALSE, width = 80, align_env = "aligned") {
+  if (aligned & !align_env %in% c("aligned", "aligned*", "algin", "align*"))
+    warning("align_env must be one of 'aligned', 'aligned*', 'align', or 'align*'")
+  if (aligned & !is.numeric(width) | width <= 0)
+    warning("width must be a positive integer")
+
   lhs  <- all.vars(formula(model))[1]
 
   formula_rhs <- labels(terms(formula(model)))
@@ -63,14 +83,29 @@ extract_eq_lm <- function(model, preview = FALSE, use_text = FALSE) {
   full_rhs <- unlist(dummied[formula_rhs])
 
   # Construct TeX
-  lhs_eq <- paste(lhs, "= ")
-
   betas <- paste0("\\beta_{", seq_along(full_rhs), "}(")
   rhs_eq <- paste0(betas, full_rhs, ")")
   rhs_eq <- paste("\\alpha +", paste(rhs_eq, collapse = " + "))
   error <- "+ \\epsilon"
 
-  eq <- paste("$$\n", paste0(lhs_eq, rhs_eq), error, "\n$$")
+  if (aligned) {
+    lhs_eq <- paste(lhs, "=& ")
+
+    # Wrap equation
+    math_wrapped <- strwrap(paste(paste0(lhs_eq, rhs_eq), error),
+                            width = width, prefix = "& ", initial = "")
+
+    # Build aligned environment
+    eq <- paste0("$$\n",
+                 "\\begin{", align_env, "}\n",
+                 paste(math_wrapped, collapse = " \\\\\n"),
+                 "\n\\end{", align_env, "}",
+                 "\n$$")
+  } else {
+    lhs_eq <- paste(lhs, "= ")
+
+    eq <- paste("$$\n", paste0(lhs_eq, rhs_eq), error, "\n$$")
+  }
 
   if (preview) {
     if (!requireNamespace("texPreview", quietly = TRUE)) {
@@ -79,5 +114,6 @@ extract_eq_lm <- function(model, preview = FALSE, use_text = FALSE) {
     }
     return(texPreview::tex_preview(eq))
   }
+
   cat(eq)
 }

--- a/man/extract_eq_lm.Rd
+++ b/man/extract_eq_lm.Rd
@@ -4,7 +4,8 @@
 \alias{extract_eq_lm}
 \title{Latex code for `lm` models}
 \usage{
-extract_eq_lm(model, preview = FALSE, use_text = FALSE)
+extract_eq_lm(model, preview = FALSE, use_text = FALSE,
+  aligned = FALSE, width = 80, align_env = "aligned")
 }
 \arguments{
 \item{model}{A fitted `lm` model}
@@ -13,7 +14,18 @@ extract_eq_lm(model, preview = FALSE, use_text = FALSE)
 previewed in the viewer pane?}
 
 \item{use_text}{Logical, defaults to \code{FALSE}. Should the variable names
-be wrapped in the \code{\\text{}} command}
+be wrapped in the \code{\\text{}} command?}
+
+\item{aligned}{Logical, defaults to \code{FALSE}. Should the equation be
+inserted in a special \code{aligned} TeX environment and automatically
+wrapped to a specific width?}
+
+\item{width}{Integer, defaults to 80. The suggested of characters per line in
+the split equation. Used only when \code{aligned} is \code{TRUE}}
+
+\item{align_env}{TeX environment to wrap around equation. Must be one of
+\code{aligned}, \code{aligned*}, \code{align}, or \code{align*}. Defaults
+to \code{aligned}}
 }
 \description{
 Uses the variable names supplied to \link[stats]{lm} to produce a LaTeX
@@ -51,4 +63,10 @@ extract_eq_lm(mod1, use_text = TRUE)
 
 # Categorical variables
 extract_eq_lm(mod3, use_text = TRUE)
+
+# Wrap equations in an "aligned" environment
+extract_eq_lm(mod2, aligned = TRUE)
+
+# Wider equation wrapping
+extract_eq_lm(mod2, aligned = TRUE, width = 100)
 }


### PR DESCRIPTION
Voila! This is pretty neat, *and* it doesn't rely on external packages like **stringi**.

``` r
library(equatiomatic)
mod2 <- lm(mpg ~ ., mtcars)

extract_eq_lm(mod2, aligned = TRUE)
#> $$
#> \begin{aligned}
#> mpg =& \alpha + \beta_{1}(cyl) + \beta_{2}(disp) + \beta_{3}(hp) + \\
#> & \beta_{4}(drat) + \beta_{5}(wt) + \beta_{6}(qsec) + \beta_{7}(vs) + \\
#> & \beta_{8}(am) + \beta_{9}(gear) + \beta_{10}(carb) + \epsilon
#> \end{aligned}
#> $$

extract_eq_lm(mod2, aligned = TRUE, width = 100)
#> $$
#> \begin{aligned}
#> mpg =& \alpha + \beta_{1}(cyl) + \beta_{2}(disp) + \beta_{3}(hp) + \beta_{4}(drat) + \beta_{5}(wt) \\
#> & + \beta_{6}(qsec) + \beta_{7}(vs) + \beta_{8}(am) + \beta_{9}(gear) + \beta_{10}(carb) + \epsilon
#> \end{aligned}
#> $$
```
