### PR TITLE
add lookup table with common link functions

### DIFF
--- a/R/link-functions.R
+++ b/R/link-functions.R
@@ -1,0 +1,25 @@
+# link-functions.R
+
+name <- c("logit",
+          'inverse',
+          '1/mu^2', # inverse gaussian
+          'log')
+
+# not sure how to address this one: quasi(link = "identity", variance = "constant")
+
+greek_symbol <- c("log\\left[ \\frac { y }{ 1\\quad -\\quad y }  \\right]",
+                  "\\frac { 1 }{ y }",
+                  "\\frac { 1 }{ 1/{ \\mu  }^{ 2 } } ", # inverse gaussian - correct?
+                  "\\log ( { y )} ") # are the parentheses italicized here?
+
+link_function_frame <- data.frame(name, greek_symbol)
+
+# how to find the link function and distribution family
+# counts <- c(18,17,15,20,10,20,25,13,12)
+# outcome <- gl(3,1,9)
+# treatment <- gl(3,3)
+# print(d.AD <- data.frame(treatment, outcome, counts))
+# glm.D93 <- glm(counts ~ outcome + treatment, family = poisson())
+#
+# glm.D93$family$link
+# glm.D93$family$family


### PR DESCRIPTION
This adds a lookup table for link functions and an example for how to extract the link function (and distribution family). 

I identified the candidate link functions from `?stats::family()` (which seems to be what `glm()` uses). 

I think it's pretty uncommon, but I wasn't sure how to deal with the following family/link, so I didn't include it, yet:

* `quasi(link = "identity", variance = "constant")`

I also added a note that I wasn't sure how I wrote this one was right, and so I pretty much wrote exactly as follows:

* `inverse.gaussian(link = "1/mu^2")` 

Would be happy to work on how to build this into the other functions; going to leave this open for a bit and wait until #20 is merged to go about that. Also, welcome feedback, suggested changes, or changes to any and all parts of this - it's (going to be) my first time diving into the codebase and I'd like to not make more work for you - and us - in the process!