### PR TITLE
More flexible coef greek

### DIFF
--- a/R/create_eq.R
+++ b/R/create_eq.R
@@ -13,13 +13,14 @@ create_eq <- function(lhs,...) {
 #'
 #' @inheritParams extract_eq
 
-create_eq.default <- function(lhs, rhs, ital_vars, use_coefs, coef_digits, fix_signs, model, intercept) {
+create_eq.default <- function(lhs, rhs, ital_vars, use_coefs, coef_digits,
+                              fix_signs, model, intercept, greek, raw_tex) {
   rhs$final_terms <- create_term(rhs, ital_vars)
 
   if (use_coefs) {
     rhs$final_terms <- add_coefs(rhs, rhs$final_terms, coef_digits)
   } else {
-    rhs$final_terms <- add_greek(rhs, rhs$final_terms, intercept)
+    rhs$final_terms <- add_greek(rhs, rhs$final_terms, greek, intercept, raw_tex)
   }
 
   # Add error row
@@ -38,7 +39,7 @@ create_eq.polr <- function(lhs, rhs, ital_vars, use_coefs, coef_digits,
   if (use_coefs) {
     rhs$final_terms <- add_coefs(rhs, rhs$final_terms, coef_digits)
   } else {
-    rhs$final_terms <- add_greek(rhs, rhs$final_terms)
+    rhs$final_terms <- add_greek(rhs, rhs$final_terms, greek, intercept, raw_tex)
   }
 
   splt <- split(rhs, rhs$coefficient_type)
@@ -209,18 +210,18 @@ add_greek <- function(rhs, ...) {
 #' Adds greek symbols to the equation
 #'
 #' @keywords internal
-
-add_greek.default <- function(rhs, terms, intercept = "alpha") {
+add_greek.default <- function(rhs, terms, greek = "beta", intercept = "alpha",
+                              raw_tex = FALSE) {
   int <- switch(intercept,
                 "alpha" = "\\alpha",
                 "beta" = "\\beta_{0}")
 
   if (any(grepl("(Intercept)", terms))) {
-    anno_greek("beta", seq_len(nrow(rhs)), terms)
+    anno_greek(greek, seq_len(nrow(rhs)), terms)
   } else {
     ifelse(rhs$term == "(Intercept)",
            int,
-           anno_greek("beta", seq_len(nrow(rhs)) - 1, terms)
+           anno_greek(greek, seq_len(nrow(rhs)) - 1, terms, raw_tex)
            )
   }
 }
@@ -239,12 +240,16 @@ add_greek.polr <- function(rhs, terms) {
 #'
 #' @keywords internal
 
-anno_greek <- function(greek, nums, terms = NULL) {
-  greek <- paste0("\\", greek, "_{", nums,"}")
-  if(!is.null(terms)) {
-    greek <- paste0(greek, "(", terms, ")")
+anno_greek <- function(greek, nums, terms = NULL, raw_tex = FALSE) {
+  if(raw_tex) {
+    out <- paste0(greek, "_{", nums,"}")
+  } else {
+    out <- paste0("\\", greek, "_{", nums,"}")
   }
-  greek
+  if(!is.null(terms)) {
+    out <- paste0(out, "(", terms, ")")
+  }
+  out
 }
 
 

--- a/R/extract_eq.R
+++ b/R/extract_eq.R
@@ -6,8 +6,14 @@
 #'
 #' @param model A fitted model
 #' @param intercept How should the intercept be displayed? Default is \code{"alpha"},
-#' but can also accept \code{"beta"}, in which case the it will be displayed
-#' as beta zero.
+#'   but can also accept \code{"beta"}, in which case the it will be displayed
+#'   as beta zero.
+#' @param greek What notation should be used for
+#'   coefficients? Currently only accepts \code{"beta"} (with plans for future
+#'   development). Can be used in combination with \code{raw_tex} to use any
+#'   notation, e.g., \code{"\\hat{\\beta}"}.
+#' @param raw_tex Logical. Is the greek code being passed to denote coefficients
+#' raw tex code?
 #' @param ital_vars Logical, defaults to \code{FALSE}. Should the variable names
 #'   not be wrapped in the \code{\\text{}} command?
 #' @param wrap Logical, defaults to \code{FALSE}. Should the terms on the
@@ -82,7 +88,8 @@
 #' mod5 <- glm(out ~ ., data = d, family = binomial(link = "logit"))
 #' extract_eq(mod5, wrap = TRUE)
 
-extract_eq <- function(model, intercept = "alpha", ital_vars = FALSE,
+extract_eq <- function(model, intercept = "alpha", greek = "beta",
+                       raw_tex = FALSE, ital_vars = FALSE,
                        wrap = FALSE, terms_per_line = 4,
                        operator_location = "end", align_env = "aligned",
                        use_coefs = FALSE, coef_digits = 2, fix_signs = TRUE) {
@@ -97,7 +104,9 @@ extract_eq <- function(model, intercept = "alpha", ital_vars = FALSE,
                       coef_digits,
                       fix_signs,
                       model,
-                      intercept)
+                      intercept,
+                      greek,
+                      raw_tex)
 
   if (wrap) {
     if (operator_location == "start") {

--- a/man/add_greek.default.Rd
+++ b/man/add_greek.default.Rd
@@ -4,7 +4,7 @@
 \alias{add_greek.default}
 \title{Adds greek symbols to the equation}
 \usage{
-\method{add_greek}{default}(rhs, terms, intercept = "alpha")
+\method{add_greek}{default}(rhs, terms, greek = "beta", intercept = "alpha", raw_tex = FALSE)
 }
 \description{
 Adds greek symbols to the equation

--- a/man/anno_greek.Rd
+++ b/man/anno_greek.Rd
@@ -4,7 +4,7 @@
 \alias{anno_greek}
 \title{Intermediary function to wrap text in \verb{\\\\beta_\{\}}}
 \usage{
-anno_greek(greek, nums, terms = NULL)
+anno_greek(greek, nums, terms = NULL, raw_tex = FALSE)
 }
 \description{
 Intermediary function to wrap text in \verb{\\\\beta_\{\}}

--- a/man/create_eq.default.Rd
+++ b/man/create_eq.default.Rd
@@ -12,7 +12,9 @@
   coef_digits,
   fix_signs,
   model,
-  intercept
+  intercept,
+  greek,
+  raw_tex
 )
 }
 \arguments{
@@ -41,6 +43,14 @@ coefficient estimates that are negative are preceded with a "+" (e.g.
 \item{intercept}{How should the intercept be displayed? Default is \code{"alpha"},
 but can also accept \code{"beta"}, in which case the it will be displayed
 as beta zero.}
+
+\item{greek}{What notation should be used for
+coefficients? Currently only accepts \code{"beta"} (with plans for future
+development). Can be used in combination with \code{raw_tex} to use any
+notation, e.g., \code{"\\hat{\\beta}"}.}
+
+\item{raw_tex}{Logical. Is the greek code being passed to denote coefficients
+raw tex code?}
 }
 \description{
 Create the full equation

--- a/man/extract_eq.Rd
+++ b/man/extract_eq.Rd
@@ -7,6 +7,8 @@
 extract_eq(
   model,
   intercept = "alpha",
+  greek = "beta",
+  raw_tex = FALSE,
   ital_vars = FALSE,
   wrap = FALSE,
   terms_per_line = 4,
@@ -23,6 +25,14 @@ extract_eq(
 \item{intercept}{How should the intercept be displayed? Default is \code{"alpha"},
 but can also accept \code{"beta"}, in which case the it will be displayed
 as beta zero.}
+
+\item{greek}{What notation should be used for
+coefficients? Currently only accepts \code{"beta"} (with plans for future
+development). Can be used in combination with \code{raw_tex} to use any
+notation, e.g., \code{"\\hat{\\beta}"}.}
+
+\item{raw_tex}{Logical. Is the greek code being passed to denote coefficients
+raw tex code?}
 
 \item{ital_vars}{Logical, defaults to \code{FALSE}. Should the variable names
 not be wrapped in the \code{\\text{}} command?}


### PR DESCRIPTION
This is kind of neat! I included a new `raw_tex` argument that can be passed for the coefficients. For the intercept, it will still take `"alpha"` or `"beta"`, but if you have `raw_tex = TRUE` you can also use raw tex code for it. For example

![Screen Shot 2020-07-25 at 12 11 30 PM](https://user-images.githubusercontent.com/10944136/88464483-faa48880-ce6f-11ea-8e4c-0507bb8fb893.png)

Unfortunately it looks like the underscores in the variable names are messing some things up here. I feel like we had fixed that at some point but it doesn't seem to be working here...