### PR TITLE
Minor probit things

### DIFF
--- a/R/create_eq.R
+++ b/R/create_eq.R
@@ -111,8 +111,8 @@ create_term <- function(rhs, ital_vars) {
 #' @return A character string
 
 escape_tex <- function(term) {
-  unescaped <- c("&", "%", "$", "#", "_", "{", "}", "~", "^", "\\")
-  escaped <- c("\\&", "\\%", "\\$", "\\#", "\\_", "\\{", "\\}",
+  unescaped <- c(" ", "&", "%", "$", "#", "_", "{", "}", "~", "^", "\\")
+  escaped <- c("\\ ", "\\&", "\\%", "\\$", "\\#", "\\_", "\\{", "\\}",
                "\\char`\\~", "\\char`\\^", "\\backslash ")
 
   # Split term into a vector of single characters

--- a/R/extract_lhs.R
+++ b/R/extract_lhs.R
@@ -162,7 +162,7 @@ link_name <- c("logit, logistic",
 # not sure how to address this one: quasi(link = "identity", variance = "constant")
 
 link_formula <- c("\\log\\left[ \\frac { P( y ) }{ 1 - P( y ) } \\right]",
-                  "P(y | X)",
+                  "P(y)",
                   "\\frac { 1 }{ P( y ) }",
                   # "\\frac { 1 }{ 1/{ y }^{ 2 } } ", # inverse gaussian - correct?
                   "\\log ( { y )} ",

--- a/R/extract_rhs.R
+++ b/R/extract_rhs.R
@@ -211,7 +211,7 @@ wrap_rhs.default <- function(model, tex, ...) {
 #' @keywords internal
 wrap_rhs.glm <- function(model, tex, ...) {
   if (model$family$link == "probit") {
-    rhs <- paste0("\\phi(", tex, ")")
+    rhs <- paste0("\\Phi[", tex, "]")
   } else {
     rhs <- tex
   }
@@ -222,7 +222,7 @@ wrap_rhs.glm <- function(model, tex, ...) {
 #' @keywords internal
 wrap_rhs.polr <- function(model, tex, ...) {
   if (model$method == "probit") {
-    rhs <- paste0("\\phi(", tex, ")")
+    rhs <- paste0("\\Phi[", tex, "]")
   } else {
     rhs <- tex
   }
@@ -233,7 +233,7 @@ wrap_rhs.polr <- function(model, tex, ...) {
 #' @keywords internal
 wrap_rhs.clm <- function(model, tex, ...) {
   if (model$info$link == "probit") {
-    rhs <- paste0("\\phi(", tex, ")")
+    rhs <- paste0("\\Phi[", tex, "]")
   } else {
     rhs <- tex
   }

--- a/tests/testthat/test-clm.R
+++ b/tests/testthat/test-clm.R
@@ -27,12 +27,12 @@ test_that("Ordered models with clm work", {
 \\log\\left[ \\frac { P( \\operatorname{B} \\geq \\operatorname{C} ) }{ 1 - P( \\operatorname{B} \\geq \\operatorname{C} ) } \\right] &= \\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon
 \\end{aligned}"
 
-  actual_nowrap_probit <- "P(\\operatorname{A} \\geq \\operatorname{B} | X) = \\phi(\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon) \\\\
-P(\\operatorname{B} \\geq \\operatorname{C} | X) = \\phi(\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon)"
+  actual_nowrap_probit <- "P(\\operatorname{A} \\geq \\operatorname{B}) = \\Phi[\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon] \\\\
+P(\\operatorname{B} \\geq \\operatorname{C}) = \\Phi[\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon]"
 
   actual_wrap_probit <- "\\begin{aligned}
-P(\\operatorname{A} \\geq \\operatorname{B} | X) &= \\phi(\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon) \\\\
-P(\\operatorname{B} \\geq \\operatorname{C} | X) &= \\phi(\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon)
+P(\\operatorname{A} \\geq \\operatorname{B}) &= \\Phi[\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon] \\\\
+P(\\operatorname{B} \\geq \\operatorname{C}) &= \\Phi[\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon]
 \\end{aligned}"
 
   expect_equal(tex_nowrap_logit, equation_class(actual_nowrap_logit),

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -28,7 +28,7 @@ test_that("Probit regression works", {
                       family = binomial(link = "probit"))
 
   tex <- extract_eq(model_probit)
-  actual <- "P(\\operatorname{outcome} = \\operatorname{1} | X) = \\phi(\\alpha + \\beta_{1}(\\operatorname{categorical}_{\\operatorname{b}}) + \\beta_{2}(\\operatorname{categorical}_{\\operatorname{c}}) + \\beta_{3}(\\operatorname{continuous\\_1}) + \\beta_{4}(\\operatorname{continuous\\_2}) + \\epsilon)"
+  actual <- "P(\\operatorname{outcome} = \\operatorname{1}) = \\Phi[\\alpha + \\beta_{1}(\\operatorname{categorical}_{\\operatorname{b}}) + \\beta_{2}(\\operatorname{categorical}_{\\operatorname{c}}) + \\beta_{3}(\\operatorname{continuous\\_1}) + \\beta_{4}(\\operatorname{continuous\\_2}) + \\epsilon]"
 
   expect_equal(tex, equation_class(actual),
                label = "basic equation builds correctly")

--- a/tests/testthat/test-polr.R
+++ b/tests/testthat/test-polr.R
@@ -25,12 +25,12 @@ test_that("Ordered logistic regression works", {
 \\log\\left[ \\frac { P( \\operatorname{B} \\geq \\operatorname{C} ) }{ 1 - P( \\operatorname{B} \\geq \\operatorname{C} ) } \\right] &= \\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon
 \\end{aligned}"
 
-  actual_nowrap_probit <- "P(\\operatorname{A} \\geq \\operatorname{B} | X) = \\phi(\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon) \\\\
-P(\\operatorname{B} \\geq \\operatorname{C} | X) = \\phi(\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon)"
+  actual_nowrap_probit <- "P(\\operatorname{A} \\geq \\operatorname{B}) = \\Phi[\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon] \\\\
+P(\\operatorname{B} \\geq \\operatorname{C}) = \\Phi[\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon]"
 
   actual_wrap_probit <- "\\begin{aligned}
-P(\\operatorname{A} \\geq \\operatorname{B} | X) &= \\phi(\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon) \\\\
-P(\\operatorname{B} \\geq \\operatorname{C} | X) &= \\phi(\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon)
+P(\\operatorname{A} \\geq \\operatorname{B}) &= \\Phi[\\alpha_{1} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon] \\\\
+P(\\operatorname{B} \\geq \\operatorname{C}) &= \\Phi[\\alpha_{2} + \\beta_{1}(\\operatorname{continuous\\_1}) + \\beta_{2}(\\operatorname{continuous\\_2}) + \\epsilon]
 \\end{aligned}"
 
   expect_equal(tex_nowrap, equation_class(actual_nowrap),


### PR DESCRIPTION
- Escape spaces in variable names, since `operatorname` removes them
- Better formatting for probit:
    - Removed `| X` from the LHS, since that's implied in all the models anyway
    - Use `\Phi` instead of `\phi` and `[]` instead of `()`