### PR TITLE
Alternative binomial notation

### DIFF
--- a/R/extract_eq.R
+++ b/R/extract_eq.R
@@ -98,6 +98,9 @@ extract_eq <- function(model, intercept = "alpha", greek = "beta",
                        wrap = FALSE, terms_per_line = 4,
                        operator_location = "end", align_env = "aligned",
                        use_coefs = FALSE, coef_digits = 2, fix_signs = TRUE) {
+  if(show_distribution) {
+    wrap <- TRUE
+  }
 
   lhs <- extract_lhs(model, ital_vars, show_distribution)
   rhs <- extract_rhs(model)

--- a/R/extract_eq.R
+++ b/R/extract_eq.R
@@ -16,6 +16,9 @@
 #' raw tex code?
 #' @param ital_vars Logical, defaults to \code{FALSE}. Should the variable names
 #'   not be wrapped in the \code{\\operatorname{}} command?
+#' @param show_distribution Logical. When fitting a logistic or probit
+#'   regression, should the binomial distribution be displayed? Defaults to
+#'   \code{FALSE}.
 #' @param wrap Logical, defaults to \code{FALSE}. Should the terms on the
 #'   right-hand side of the equation be split into multiple lines? This is
 #'   helpful with models with many terms.
@@ -91,11 +94,12 @@
 
 extract_eq <- function(model, intercept = "alpha", greek = "beta",
                        raw_tex = FALSE, ital_vars = FALSE,
+                       show_distribution = FALSE,
                        wrap = FALSE, terms_per_line = 4,
                        operator_location = "end", align_env = "aligned",
                        use_coefs = FALSE, coef_digits = 2, fix_signs = TRUE) {
 
-  lhs <- extract_lhs(model, ital_vars)
+  lhs <- extract_lhs(model, ital_vars, show_distribution)
   rhs <- extract_rhs(model)
 
   eq_raw <- create_eq(lhs,

--- a/R/extract_lhs.R
+++ b/R/extract_lhs.R
@@ -54,9 +54,13 @@ extract_lhs.glm <- function(model, ital_vars, show_distribution, ...) {
   lhs_escaped <- escape_tex(lhs)
   ss_escaped <- escape_tex(ss)
 
-  full_lhs <- paste(add_tex_ital_v(lhs_escaped, ital_vars),
-                    "=",
-                    add_tex_ital_v(ss_escaped, ital_vars))
+  if(is.na(ss)) {
+    full_lhs <- add_tex_ital_v(lhs_escaped, ital_vars)
+  } else {
+    full_lhs <- paste(add_tex_ital_v(lhs_escaped, ital_vars),
+                      "=",
+                      add_tex_ital_v(ss_escaped, ital_vars))
+  }
 
   modify_lhs_for_link(model, full_lhs)
 }

--- a/R/extract_lhs.R
+++ b/R/extract_lhs.R
@@ -20,7 +20,7 @@ extract_lhs <- function(model, ...) {
 #'
 #' @return A character string
 
-extract_lhs.lm <- function(model, ital_vars) {
+extract_lhs.lm <- function(model, ital_vars, ...) {
   lhs <- all.vars(formula(model))[1]
 
   lhs_escaped <- escape_tex(lhs)
@@ -39,7 +39,7 @@ extract_lhs.lm <- function(model, ital_vars) {
 #'
 #' @return A character string
 
-extract_lhs.glm <- function(model, ital_vars, show_distribution) {
+extract_lhs.glm <- function(model, ital_vars, show_distribution, ...) {
   if(show_distribution) {
     return(extract_lhs2.glm(model, ital_vars))
   }
@@ -61,9 +61,18 @@ extract_lhs.glm <- function(model, ital_vars, show_distribution) {
   modify_lhs_for_link(model, full_lhs)
 }
 
-extract_lhs2.glm <- function(model, ital_vars) {
+extract_lhs2.glm <- function(model, ital_vars, ...) {
   outcome <- all.vars(formula(model))[1]
-  n <- nrow(model$data)
+  n <- unique(model$model$`(weights)`)
+  if(is.null(n)) {
+    n <- nrow(model$data)
+  }
+  if(length(n) > 1) {
+    warning(paste("Unsure of how to handle a vector of weights in creation",
+                  "of the distrubtion portion of the equation. Please inspect",
+                  "carefully and modify by hand if neccessary.")
+    )
+  }
 
   # This returns a 1x1 data.frame
   ss <- model$data[which(model$y == 1)[1], outcome]
@@ -74,14 +83,19 @@ extract_lhs2.glm <- function(model, ital_vars) {
   outcome_escaped <- escape_tex(outcome)
   ss_escaped <- escape_tex(ss)
 
-  lhs <- paste0(add_tex_ital_v(outcome_escaped, ital_vars),
-                add_tex_subscripts(
-                  add_tex_ital_v(ss_escaped, ital_vars)
+  if(is.na(ss)) {
+    lhs <- add_tex_ital_v(outcome_escaped, ital_vars)
+  } else {
+    lhs <- paste0(add_tex_ital_v(outcome_escaped, ital_vars),
+                  add_tex_subscripts(
+                    add_tex_ital_v(ss_escaped, ital_vars)
                   )
-                )
+    )
+  }
 
-  rhs <- paste0("B\\left(\\operatorname{prob} = \\hat{P}, size = ",
-                n,
+  rhs <- paste0("B\\left(",
+                "\\operatorname{prob} = \\hat{P},",
+                "\\operatorname{size} = ", n,
                 "\\right)")
 
   topline <- paste(lhs, "&\\sim", rhs)
@@ -104,7 +118,7 @@ extract_lhs2.glm <- function(model, ital_vars) {
 #' @return A character string
 #'
 
-extract_lhs.polr <- function(model, ital_vars) {
+extract_lhs.polr <- function(model, ital_vars, ...) {
   tidied <- broom::tidy(model)
   lhs <- tidied$term[tidied$coef.type == "scale"]
   lhs_escaped <- mapply_chr(escape_tex, lhs)
@@ -130,7 +144,7 @@ extract_lhs.polr <- function(model, ital_vars) {
 #'
 #' @return A character string
 
-extract_lhs.clm <- function(model, ital_vars) {
+extract_lhs.clm <- function(model, ital_vars, ...) {
   tidied <- broom::tidy(model)
   lhs <- tidied$term[tidied$coef.type == "intercept"]
   lhs_escaped <- mapply_chr(escape_tex, lhs)

--- a/R/extract_lhs.R
+++ b/R/extract_lhs.R
@@ -39,7 +39,10 @@ extract_lhs.lm <- function(model, ital_vars) {
 #'
 #' @return A character string
 
-extract_lhs.glm <- function(model, ital_vars) {
+extract_lhs.glm <- function(model, ital_vars, show_distribution) {
+  if(show_distribution) {
+    return(extract_lhs2.glm(model, ital_vars))
+  }
   lhs <- all.vars(formula(model))[1]
 
   # This returns a 1x1 data.frame
@@ -57,6 +60,37 @@ extract_lhs.glm <- function(model, ital_vars) {
 
   modify_lhs_for_link(model, full_lhs)
 }
+
+extract_lhs2.glm <- function(model, ital_vars) {
+  outcome <- all.vars(formula(model))[1]
+  n <- nrow(model$data)
+
+  # This returns a 1x1 data.frame
+  ss <- model$data[which(model$y == 1)[1], outcome]
+
+  # Convert to single character
+  ss <- as.character(unlist(ss))
+
+  outcome_escaped <- escape_tex(outcome)
+  ss_escaped <- escape_tex(ss)
+
+  lhs <- paste0(add_tex_ital_v(outcome_escaped, ital_vars),
+                add_tex_subscripts(
+                  add_tex_ital_v(ss_escaped, ital_vars)
+                  )
+                )
+
+  rhs <- paste0("B\\left(\\operatorname{prob} = \\hat{P}, size = ",
+                n,
+                "\\right)")
+
+  topline <- paste(lhs, "&\\sim", rhs)
+  second_line <- "\\log\\left[ \\frac {\\hat{P}}{1 - \\hat{P}} \\right]"
+
+  paste(topline, "\\\\\n", second_line, "\n")
+}
+
+
 
 #' Extract left-hand side of a polr object
 #'

--- a/man/extract_eq.Rd
+++ b/man/extract_eq.Rd
@@ -10,6 +10,7 @@ extract_eq(
   greek = "beta",
   raw_tex = FALSE,
   ital_vars = FALSE,
+  show_distribution = FALSE,
   wrap = FALSE,
   terms_per_line = 4,
   operator_location = "end",
@@ -36,6 +37,10 @@ raw tex code?}
 
 \item{ital_vars}{Logical, defaults to \code{FALSE}. Should the variable names
 not be wrapped in the \code{\\operatorname{}} command?}
+
+\item{show_distribution}{Logical. When fitting a logistic or probit
+regression, should the binomial distribution be displayed? Defaults to
+\code{FALSE}.}
 
 \item{wrap}{Logical, defaults to \code{FALSE}. Should the terms on the
 right-hand side of the equation be split into multiple lines? This is

--- a/man/extract_lhs.clm.Rd
+++ b/man/extract_lhs.clm.Rd
@@ -4,7 +4,7 @@
 \alias{extract_lhs.clm}
 \title{Extract left-hand side of a clm object}
 \usage{
-\method{extract_lhs}{clm}(model, ital_vars)
+\method{extract_lhs}{clm}(model, ital_vars, ...)
 }
 \arguments{
 \item{model}{A fitted model}

--- a/man/extract_lhs.glm.Rd
+++ b/man/extract_lhs.glm.Rd
@@ -4,13 +4,17 @@
 \alias{extract_lhs.glm}
 \title{Extract left-hand side of a glm object}
 \usage{
-\method{extract_lhs}{glm}(model, ital_vars)
+\method{extract_lhs}{glm}(model, ital_vars, show_distribution)
 }
 \arguments{
 \item{model}{A fitted model}
 
 \item{ital_vars}{Logical, defaults to \code{FALSE}. Should the variable names
 not be wrapped in the \code{\\operatorname{}} command?}
+
+\item{show_distribution}{Logical. When fitting a logistic or probit
+regression, should the binomial distribution be displayed? Defaults to
+\code{FALSE}.}
 }
 \value{
 A character string

--- a/man/extract_lhs.glm.Rd
+++ b/man/extract_lhs.glm.Rd
@@ -4,7 +4,7 @@
 \alias{extract_lhs.glm}
 \title{Extract left-hand side of a glm object}
 \usage{
-\method{extract_lhs}{glm}(model, ital_vars, show_distribution)
+\method{extract_lhs}{glm}(model, ital_vars, show_distribution, ...)
 }
 \arguments{
 \item{model}{A fitted model}

--- a/man/extract_lhs.lm.Rd
+++ b/man/extract_lhs.lm.Rd
@@ -4,7 +4,7 @@
 \alias{extract_lhs.lm}
 \title{Extract left-hand side of an lm object}
 \usage{
-\method{extract_lhs}{lm}(model, ital_vars)
+\method{extract_lhs}{lm}(model, ital_vars, ...)
 }
 \arguments{
 \item{model}{A fitted model}

--- a/man/extract_lhs.polr.Rd
+++ b/man/extract_lhs.polr.Rd
@@ -4,7 +4,7 @@
 \alias{extract_lhs.polr}
 \title{Extract left-hand side of a polr object}
 \usage{
-\method{extract_lhs}{polr}(model, ital_vars)
+\method{extract_lhs}{polr}(model, ital_vars, ...)
 }
 \arguments{
 \item{model}{A fitted model}


### PR DESCRIPTION
Okay, so as mentioned in #49, this is a bit ad hoc, but it works. In addition to the examples shown there, I've also now made it so it accounts for weights and will drop subscripts if they're not present. That means the example #49 started with now works too.

```r
library(equatiomatic)
dat = data.frame(counts = c(18,17,15,20,10,20,25,13,12), 
                 treatment = gl(3,3), 
                 trials = 30)

model <- glm(counts/30 ~  treatment, weights = dat$trials, family = binomial(), data = dat)
extract_eq(model)
```

![Screen Shot 2020-07-30 at 7 41 41 PM](https://user-images.githubusercontent.com/10944136/88994216-b284cc00-d29c-11ea-93c2-c3c829f93e7b.png)

```r
extract_eq(model, show_distribution = TRUE)
```

![Screen Shot 2020-07-30 at 7 41 53 PM](https://user-images.githubusercontent.com/10944136/88994230-b9abda00-d29c-11ea-9a19-ecfcabeb7f79.png)
