### PR TITLE
Should do the trick

### DIFF
--- a/R/extract_rhs.R
+++ b/R/extract_rhs.R
@@ -128,7 +128,7 @@ extract_primary_term <- function(primary_term_v, all_terms) {
 
 detect_primary <- function(full_term, primary_term_v) {
   vapply(primary_term_v, function(indiv_term) {
-    grepl(indiv_term, full_term)
+    grepl(indiv_term, full_term, fixed = TRUE)
   },
   logical(1)
   )
@@ -181,8 +181,8 @@ extract_all_subscripts <- function(primary_list, full_term_list) {
 extract_subscripts <- function(primary, full_term_v) {
   out <- switch(as.character(length(primary)),
                 "0" = "",
-                "1" = gsub(primary, "", full_term_v),
-                mapply_chr(function(x, y) gsub(x, "", y),
+                "1" = gsub(primary, "", full_term_v, fixed = TRUE),
+                mapply_chr(function(x, y) gsub(x, "", y, fixed = TRUE),
                            x = primary,
                            y = full_term_v)
   )


### PR DESCRIPTION
Just had to add `fixed = TRUE` to a few `grepl` functions.

```r
library(equatiomatic)
m1 <- lm(mpg ~ scale(cyl) + disp, mtcars)
m2 <- lm(mpg ~ I(cyl/sd(cyl)) + disp, mtcars)
extract_eq(m1)
```
<img width="450" alt="Screen Shot 2020-07-30 at 9 28 02 PM" src="https://user-images.githubusercontent.com/10944136/89000176-8e7cb700-d2ab-11ea-9f1c-88acb5cca91d.png">

```r
extract_eq(m2)
```

<img width="479" alt="Screen Shot 2020-07-30 at 9 28 12 PM" src="https://user-images.githubusercontent.com/10944136/89000184-94729800-d2ab-11ea-81d3-664ac9d8fa9a.png">


This should address #42. Related for #72, do we want to try to partially address #14  before CRAN too? For the lhs of things this still gets wiped, but we could probably make that not the case fairly easily.

