### PR TITLE
partially addresses #14

### DIFF
--- a/R/extract_lhs.R
+++ b/R/extract_lhs.R
@@ -21,7 +21,7 @@ extract_lhs <- function(model, ...) {
 #' @return A character string
 
 extract_lhs.lm <- function(model, ital_vars, ...) {
-  lhs <- all.vars(formula(model))[1]
+  lhs <- rownames(attr(model$terms, "factors"))[1]
 
   lhs_escaped <- escape_tex(lhs)
   add_tex_ital_v(lhs_escaped, ital_vars)


### PR DESCRIPTION
This doesn't actually turn it into `\log` but it keeps `log` in there on the lhs. Probably wouldn't be TOO big of a deal to create a quick wrapper that checks the lhs for `log` and switches it to `\log`. Maybe we should do that too? I'll keep this branch open for a bit before merging.

```r 
library(equatiomatic)
m1 <- lm(log(mpg) ~ scale(cyl) + disp, mtcars)
extract_eq(m1)
```
<img width="477" alt="Screen Shot 2020-07-30 at 9 41 47 PM" src="https://user-images.githubusercontent.com/10944136/89000939-8291f480-d2ad-11ea-847e-63b6d9836160.png">
