### PR TITLE
try to fix texlib stuff for covrpage

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,7 +29,13 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
+  
+      - name: Install magick
+        run: brew install imagemagick
+        
+      - name: Install texlibs
+        run: tlmgr install standalone xcolor booktabs multirow amsmath listings setspace caption graphics tools psnfss varwidth colortbl epstopdf-pkg pgf
+      
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)


### PR DESCRIPTION
Installing magick and tex for pkgdown only, which should be easier than other tries because it's just for macOS (which is what's used for pkgdown deploy).