### PR TITLE
Change returnType to html when rendering a reprex

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -29,12 +29,17 @@ print.equation <- function(x, ...) {
 #'
 knit_print.equation <- function(x,...,tex_packages = "\\renewcommand*\\familydefault{\\rmdefault}"){
   eq <- format(x)
-  if(isTRUE(knitr::opts_knit$get("rmarkdown.pandoc.to") == "gfm")){
+  if(isTRUE(knitr::opts_knit$get("rmarkdown.pandoc.to") %in% c("gfm", "markdown_strict"))){
     if (!is_texPreview_installed()) {
       message("Please install \"{texPreview}\" with `install.packages(\"texPreview\")` for equations to render with GitHub flavored markdown. Defaulting to raw TeX code.", call. = FALSE)
       print(eq)
     } else {
       knit_print(texPreview::tex_preview(eq, usrPackages = tex_packages))
+      if(knitr::opts_knit$get("rmarkdown.pandoc.to") == "markdown_strict") {
+        knit_print(texPreview::tex_preview(eq, usrPackages = tex_packages,
+                                           returnType = "html",
+                                           density = 300))
+      }
     }
   }else{
     return(knitr::asis_output(eq))


### PR DESCRIPTION
This should make it so reprex works now. The only thing I'm not sure of how to fix is that the equations get cutoff. In the README it looks like we have the `out.width = 100%` but I don't know how to automatically do that within a reprex.

Quick example.

``` r
library(equatiomatic)
m <- lm(bill_depth_mm ~ body_mass_g*island, penguins)
extract_eq(m, wrap = 2)
#> NULL
```

<img src="https://i.imgur.com/Vo1tnHe.png" width="1515" />

<sup>Created on 2020-09-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>