### PR TITLE
add pkgdown url to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Suggests:
     forecast (>= 8.13),
     latex2exp (>= 0.4.0),
     ggplot2(>= 3.3.2)
-URL: https://github.com/datalorax/equatiomatic
+URL: https://github.com/datalorax/equatiomatic, https://datalorax.github.io/equatiomatic/
 BugReports: https://github.com/datalorax/equatiomatic/issues
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
This makes the `pkgdown` website discoverable from `CRAN` itself. 😊