### PR TITLE
add \n at the end of `format.equation`

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -72,5 +72,5 @@ is_texPreview_installed <- function() {
 #' @param ... not used
 #' @noRd
 format.equation <- function(x, ...) {
-  paste0(c("$$\n", x, "\n$$"), collapse = "")
+  paste0(c("$$\n", x, "\n$$\n"), collapse = "")
 }

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -23,7 +23,7 @@ test_that("Equation is knit_print-ed correctly", {
   knit_print_tex <- knitr::knit_print(extract_eq(model_simple))
   actual <- paste(
     "$$\n\\operatorname{mpg} = \\alpha + \\beta_{1}(\\operatorname{cyl}) +",
-    "\\beta_{2}(\\operatorname{disp}) + \\epsilon\n$$"
+    "\\beta_{2}(\\operatorname{disp}) + \\epsilon\n$$\n"
   )
 
   expect_equal(as.character(knit_print_tex),


### PR DESCRIPTION
After printing an equation on console, the closing `$$` is in the same line that the next line instruction `>`. Therefore, I added the `\n` in order to let the next instruction be written in a separate line of that of `$$`.
I just have the doubt (you may arrange it as you prefer), if it is better add the `\n` in `format.equation` as I did or in `print.equation` by means of `cat(format(x), "\n", sep = "")`