### PR TITLE
add font_size argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # equatiomatic (development version)
+* Added new `font_size` argument, which takes any LaTeX font size (see [here](https://www.overleaf.com/learn/latex/Font_sizes,_families,_and_styles#Font_styles))
 * Bug fix related to categorical variables and level parsing for `lme4::lmer()` models
 * Minor bug fix related to indexing of coefficients for `lme4::lmer()` models
 

--- a/R/extract_eq.R
+++ b/R/extract_eq.R
@@ -42,6 +42,9 @@
 #'   coefficient estimates that are negative are preceded with a "+" (e.g.
 #'   `5(x) + -3(z)`). If enabled, the "+ -" is replaced with a "-" (e.g.
 #'   `5(x) - 3(z)`).
+#' @param font_size The font size of the equation. Defaults to default of
+#'   the output format. Takes any of the standard LaTeX arguments (see 
+#'   [here](https://www.overleaf.com/learn/latex/Font_sizes,_families,_and_styles#Font_styles)).
 #' @param mean_separate Currently only support for \code{\link[lme4]{lmer}}
 #'   models. Should the mean structure be inside or separated from the
 #'   normal distribution? Defaults to \code{NULL}, in which case it will become
@@ -110,7 +113,7 @@ extract_eq <- function(model, intercept = "alpha", greek = "beta",
                        wrap = FALSE, terms_per_line = 4,
                        operator_location = "end", align_env = "aligned",
                        use_coefs = FALSE, coef_digits = 2, fix_signs = TRUE,
-                       mean_separate, ...) {
+                       font_size, mean_separate, ...) {
   UseMethod("extract_eq", model)
 }
 
@@ -125,7 +128,8 @@ extract_eq.default <- function(model, intercept = "alpha", greek = "beta",
                                wrap = FALSE, terms_per_line = 4,
                                operator_location = "end", align_env = "aligned",
                                use_coefs = FALSE, coef_digits = 2,
-                               fix_signs = TRUE, mean_separate, ...) {
+                               fix_signs = TRUE, font_size = NULL, 
+                               mean_separate, ...) {
   lhs <- extract_lhs(model, ital_vars, show_distribution, use_coefs)
   rhs <- extract_rhs(model)
 
@@ -169,7 +173,10 @@ extract_eq.default <- function(model, intercept = "alpha", greek = "beta",
     })
   }
 
-  if (wrap | length(rhs_combined) > 1 | show_distribution) {
+  if (wrap | 
+      length(rhs_combined) > 1 | 
+      show_distribution | 
+      !is.null(font_size)) {
     needs_align <- TRUE
   } else {
     needs_align <- FALSE
@@ -204,6 +211,9 @@ extract_eq.default <- function(model, intercept = "alpha", greek = "beta",
       "\n\\end{", align_env, "}"
     )
   }
+  if (!is.null(font_size)) {
+    eq <- paste0("\\", font_size, "\n", eq)
+  }
 
   class(eq) <- c("equation", "character")
 
@@ -225,7 +235,8 @@ extract_eq.lmerMod <- function(model, intercept = "alpha", greek = "beta",
                                operator_location = "end",
                                align_env = "aligned",
                                use_coefs = FALSE, coef_digits = 2,
-                               fix_signs = TRUE, mean_separate = NULL, ...) {
+                               fix_signs = TRUE, 
+                               font_size = NULL, mean_separate = NULL, ...) {
   l1 <- create_l1_merMod(model, mean_separate,
     ital_vars, wrap, terms_per_line,
     use_coefs, coef_digits, fix_signs,
@@ -249,6 +260,9 @@ extract_eq.lmerMod <- function(model, intercept = "alpha", greek = "beta",
     paste0("  ", eq),
     "\n\\end{", align_env, "}"
   )
+  if (!is.null(font_size)) {
+    eq <- paste0("\\", font_size, "\n", eq)
+  }
   class(eq) <- c("equation", "character")
 
   eq
@@ -263,7 +277,8 @@ extract_eq.forecast_ARIMA <- function(model, intercept = "alpha", greek = "beta"
                                       wrap = FALSE, terms_per_line = 4,
                                       operator_location = "end", align_env = "aligned",
                                       use_coefs = FALSE, coef_digits = 2,
-                                      fix_signs = TRUE, mean_separate, ...) {
+                                      fix_signs = TRUE, 
+                                      font_size = NULL, mean_separate, ...) {
 
   # Determine if we are working on Regerssion w/ Arima Errors
   regression <- helper_arima_is_regression(model)
@@ -335,11 +350,22 @@ extract_eq.forecast_ARIMA <- function(model, intercept = "alpha", greek = "beta"
       paste(eq, collapse = " \\\\\n"),
       "\n\\end{alignat}"
     )
+    if (!is.null(font_size)) {
+      eq <- paste0("\\", font_size, "\n", eq)
+    }
   } else {
     # If arima only then we only need 1 line and no alignment.
     eq <- eq$arima_eq
+    if (!is.null(font_size)) {
+      eq <- paste0(
+        "\\begin{aligned}\n",
+        paste(eq, collapse = " \\\\\n"),
+        "\n\\end{aligned}"
+      )
+      eq <- paste0("\\", font_size, "\n", eq)
+    }
   }
-
+  
   # Set the class
   class(eq) <- c("equation", "character")
 

--- a/man/extract_eq.Rd
+++ b/man/extract_eq.Rd
@@ -18,6 +18,7 @@ extract_eq(
   use_coefs = FALSE,
   coef_digits = 2,
   fix_signs = TRUE,
+  font_size,
   mean_separate,
   ...
 )
@@ -71,6 +72,10 @@ round to when displaying model estimates.}
 coefficient estimates that are negative are preceded with a "+" (e.g.
 \code{5(x) + -3(z)}). If enabled, the "+ -" is replaced with a "-" (e.g.
 \code{5(x) - 3(z)}).}
+
+\item{font_size}{The font size of the equation. Defaults to default of
+the output format. Takes any of the standard LaTeX arguments (see
+\href{https://www.overleaf.com/learn/latex/Font_sizes,_families,_and_styles#Font_styles}{here}).}
 
 \item{mean_separate}{Currently only support for \code{\link[lme4]{lmer}}
 models. Should the mean structure be inside or separated from the

--- a/tests/testthat/_snaps/fontsize.md
+++ b/tests/testthat/_snaps/fontsize.md
@@ -1,0 +1,87 @@
+# font-size changes, lm
+
+    $$
+    \large
+    \begin{aligned}
+    \operatorname{mpg} &= \alpha + \beta_{1}(\operatorname{cyl}) + \beta_{2}(\operatorname{disp}) + \epsilon
+    \end{aligned}
+    $$
+
+---
+
+    $$
+    \Huge
+    \begin{aligned}
+    \operatorname{mpg} &= \alpha + \beta_{1}(\operatorname{cyl}) + \beta_{2}(\operatorname{disp}) + \epsilon
+    \end{aligned}
+    $$
+
+---
+
+    $$
+    \tiny
+    \begin{aligned}
+    \operatorname{mpg} &= \alpha + \beta_{1}(\operatorname{cyl}) + \beta_{2}(\operatorname{disp}) + \epsilon
+    \end{aligned}
+    $$
+
+# font-size changes, lmer
+
+    $$
+    \scriptsize
+    \begin{aligned}
+      \operatorname{score}_{i}  &\sim N \left(\alpha_{j[i]}, \sigma^2 \right) \\
+        \alpha_{j}  &\sim N \left(\mu_{\alpha_{j}}, \sigma^2_{\alpha_{j}} \right)
+        \text{, for sid j = 1,} \dots \text{,J}
+    \end{aligned}
+    $$
+
+---
+
+    $$
+    \Large
+    \begin{aligned}
+      \operatorname{score}_{i}  &\sim N \left(\alpha_{j[i]}, \sigma^2 \right) \\
+        \alpha_{j}  &\sim N \left(\mu_{\alpha_{j}}, \sigma^2_{\alpha_{j}} \right)
+        \text{, for sid j = 1,} \dots \text{,J}
+    \end{aligned}
+    $$
+
+---
+
+    $$
+    \huge
+    \begin{aligned}
+      \operatorname{score}_{i}  &\sim N \left(\alpha_{j[i]}, \sigma^2 \right) \\
+        \alpha_{j}  &\sim N \left(\mu_{\alpha_{j}}, \sigma^2_{\alpha_{j}} \right)
+        \text{, for sid j = 1,} \dots \text{,J}
+    \end{aligned}
+    $$
+
+# font-size changes, arima
+
+    $$
+    \footnotesize
+    \begin{aligned}
+    (1 -\phi_{1}\operatorname{B} )\ (1 -\Phi_{1}\operatorname{B}^{\operatorname{4}} )\ (1 - \operatorname{B}) (y_{t} -\delta\operatorname{t}) = (1 +\theta_{1}\operatorname{B} )\ (1 +\Theta_{1}\operatorname{B}^{\operatorname{4}} )\ \varepsilon_{t}
+    \end{aligned}
+    $$
+
+---
+
+    $$
+    \small
+    \begin{aligned}
+    (1 -\phi_{1}\operatorname{B} )\ (1 -\Phi_{1}\operatorname{B}^{\operatorname{4}} )\ (1 - \operatorname{B}) (y_{t} -\delta\operatorname{t}) = (1 +\theta_{1}\operatorname{B} )\ (1 +\Theta_{1}\operatorname{B}^{\operatorname{4}} )\ \varepsilon_{t}
+    \end{aligned}
+    $$
+
+---
+
+    $$
+    \LARGE
+    \begin{aligned}
+    (1 -\phi_{1}\operatorname{B} )\ (1 -\Phi_{1}\operatorname{B}^{\operatorname{4}} )\ (1 - \operatorname{B}) (y_{t} -\delta\operatorname{t}) = (1 +\theta_{1}\operatorname{B} )\ (1 +\Theta_{1}\operatorname{B}^{\operatorname{4}} )\ \varepsilon_{t}
+    \end{aligned}
+    $$
+

--- a/tests/testthat/test-fontsize.R
+++ b/tests/testthat/test-fontsize.R
@@ -1,0 +1,26 @@
+test_that("font-size changes, lm", {
+  mod1 <- lm(mpg ~ cyl + disp, data = mtcars)
+  expect_snapshot_output(extract_eq(mod1, font_size = "large"))
+  expect_snapshot_output(extract_eq(mod1, font_size = "Huge"))
+  expect_snapshot_output(extract_eq(mod1, font_size = "tiny"))
+})
+
+test_that("font-size changes, lmer", {
+  um_long1 <- lme4::lmer(score ~ 1 + (1 | sid), data = sim_longitudinal)
+  expect_snapshot_output(extract_eq(um_long1, font_size = "scriptsize"))
+  expect_snapshot_output(extract_eq(um_long1, font_size = "Large"))
+  expect_snapshot_output(extract_eq(um_long1, font_size = "huge"))
+})
+
+test_that("font-size changes, arima", {
+  model <- forecast::Arima(simple_ts,
+                           order = c(1, 1, 1),
+                           seasonal = c(1, 0, 1),
+                           include.constant = TRUE
+  )
+  
+  expect_snapshot_output(extract_eq(model, font_size = "footnotesize"))
+  expect_snapshot_output(extract_eq(model, font_size = "small"))
+  expect_snapshot_output(extract_eq(model, font_size = "LARGE"))
+  
+})


### PR DESCRIPTION
Addresses #164 to change the font size of the equation based on the corresponding LaTeX argument (see [here](https://www.overleaf.com/learn/latex/Font_sizes,_families,_and_styles#Font_styles)).

It should work for HTML or PDF, for the most part, although "footnotesize" didn't seem to work.

![Screen Shot 2021-04-21 at 2 01 58 PM](https://user-images.githubusercontent.com/10944136/115620547-24c59280-a2aa-11eb-82d7-dbd29df5fea5.png)

![Screen Shot 2021-04-21 at 2 03 41 PM](https://user-images.githubusercontent.com/10944136/115620708-62c2b680-a2aa-11eb-862a-2362936cdf41.png)

![Screen Shot 2021-04-21 at 2 04 20 PM](https://user-images.githubusercontent.com/10944136/115620793-79690d80-a2aa-11eb-92a2-083bcc6ca002.png)

![Screen Shot 2021-04-21 at 2 04 31 PM](https://user-images.githubusercontent.com/10944136/115620807-7ff78500-a2aa-11eb-9096-356d0f3eb8db.png)
