### PR TITLE
Add `return_variances` arg for merMods

### DIFF
--- a/R/extract_eq.R
+++ b/R/extract_eq.R
@@ -52,6 +52,10 @@
 #'   \code{TRUE}, the equation will be displayed as, for example,
 #'   outcome ~ N(mu, sigma); mu = alpha + beta_1(wave). If \code{FALSE}, this
 #'   same equation would be outcome ~ N(alpha + beta, sigma).
+#' @param return_variances Logical. When \code{use_coefs = TRUE} with a mixed
+#'   effects model (e.g., \code{lme4::lmer()}), should the variances and
+#'   co-variances be returned? If \code{FALSE} (the default) standard deviations
+#'   and correlations are returned instead.
 #' @param ... Additional arguments (for future development; not currently used).
 #' @export
 #'
@@ -236,16 +240,17 @@ extract_eq.lmerMod <- function(model, intercept = "alpha", greek = "beta",
                                align_env = "aligned",
                                use_coefs = FALSE, coef_digits = 2,
                                fix_signs = TRUE, 
-                               font_size = NULL, mean_separate = NULL, ...) {
+                               font_size = NULL, mean_separate = NULL,
+                               return_variances = FALSE, ...) {
   l1 <- create_l1(model, mean_separate,
     ital_vars, wrap, terms_per_line,
     use_coefs, coef_digits, fix_signs,
     operator_location,
-    sigma = "\\sigma^2"
+    sigma = "\\sigma^2", return_variances
   )
   vcv <- create_ranef_structure_merMod(
     model, ital_vars, use_coefs, coef_digits,
-    fix_signs
+    fix_signs, return_variances
   )
 
   if (grepl("^\n    \n", vcv[[1]])) {

--- a/R/extract_eq.R
+++ b/R/extract_eq.R
@@ -117,7 +117,8 @@ extract_eq <- function(model, intercept = "alpha", greek = "beta",
                        wrap = FALSE, terms_per_line = 4,
                        operator_location = "end", align_env = "aligned",
                        use_coefs = FALSE, coef_digits = 2, fix_signs = TRUE,
-                       font_size, mean_separate, ...) {
+                       font_size, mean_separate, return_variances = FALSE,
+                       ...) {
   UseMethod("extract_eq", model)
 }
 
@@ -133,7 +134,7 @@ extract_eq.default <- function(model, intercept = "alpha", greek = "beta",
                                operator_location = "end", align_env = "aligned",
                                use_coefs = FALSE, coef_digits = 2,
                                fix_signs = TRUE, font_size = NULL, 
-                               mean_separate, ...) {
+                               mean_separate, return_variances = FALSE, ...) {
   lhs <- extract_lhs(model, ital_vars, show_distribution, use_coefs)
   rhs <- extract_rhs(model)
 
@@ -289,7 +290,8 @@ extract_eq.forecast_ARIMA <- function(model, intercept = "alpha", greek = "beta"
                                       operator_location = "end", align_env = "aligned",
                                       use_coefs = FALSE, coef_digits = 2,
                                       fix_signs = TRUE, 
-                                      font_size = NULL, mean_separate, ...) {
+                                      font_size = NULL, mean_separate, 
+                                      return_variances = FALSE, ...) {
 
   # Determine if we are working on Regerssion w/ Arima Errors
   regression <- helper_arima_is_regression(model)

--- a/R/extract_rhs.R
+++ b/R/extract_rhs.R
@@ -103,7 +103,7 @@ extract_rhs.default <- function(model) {
 
 #' @noRd
 #' @export
-extract_rhs.lmerMod <- function(model) {
+extract_rhs.lmerMod <- function(model, return_variances) {
   # Extract RHS from formula
   formula_rhs <- labels(terms(formula(model)))
 
@@ -112,8 +112,16 @@ extract_rhs.lmerMod <- function(model) {
   formula_rhs_terms <- gsub("^`?(.+)`$?", "\\1", formula_rhs_terms)
 
   # Extract coefficient names and values from model
-  full_rhs <- broom.mixed::tidy(model)
-
+  if(return_variances) {
+    full_rhs <- broom.mixed::tidy(model, scales = c("vcov", NA))
+    
+    # Make the names like they are sdcor, so it doesn't break other code
+    full_rhs$term <- gsub("var__", "sd__", full_rhs$term)
+    full_rhs$term <- gsub("cov__", "cor__", full_rhs$term)
+  } else {
+    full_rhs <- broom.mixed::tidy(model)  
+  }
+  
   full_rhs$term <- vapply(full_rhs$term, order_interaction,
     FUN.VALUE = character(1)
   )
@@ -189,8 +197,8 @@ extract_rhs.lmerMod <- function(model) {
 
 #' @noRd
 #' @export
-extract_rhs.glmerMod <- function(model) {
-  extract_rhs.lmerMod(model)
+extract_rhs.glmerMod <- function(model, ...) {
+  extract_rhs.lmerMod(model, ...)
 }
 
 #' Extract right-hand side of an forecast::Arima object

--- a/R/merMod.R
+++ b/R/merMod.R
@@ -190,8 +190,8 @@ assign_higher_levels <- function(lev_data, lev_data_name, splt, rhs_random) {
 #'   at), and a new \code{predsplit} column that allows this data frame
 #'   to be split by the level at which the variable predicts.
 #' @noRd
-create_fixef_greek_merMod <- function(model) {
-  rhs <- extract_rhs(model)
+create_fixef_greek_merMod <- function(model, return_variances) {
+  rhs <- extract_rhs(model, return_variances)
   rhs_fixed <- rhs[rhs$effect == "fixed", ]
   rhs_random <- rhs[rhs$effect == "ran_pars", ]
   rhs_random <- rhs_random[rhs_random$group != "Residual", ]
@@ -580,12 +580,13 @@ create_vcov_merMod <- function(rhs_random_lev, means_merMod,
 }
 
 create_ranef_structure_merMod <- function(model, ital_vars, use_coefs,
-                                          coef_digits, fix_signs) {
-  rhs <- extract_rhs(model)
+                                          coef_digits, fix_signs, 
+                                          return_variances) {
+  rhs <- extract_rhs(model, return_variances)
   rhs_random <- rhs[rhs$effect == "ran_pars", ]
   order <- get_order(rhs_random[rhs_random$group != "Residual", ])
   
-  fixed_greek_mermod <- create_fixef_greek_merMod(model)
+  fixed_greek_mermod <- create_fixef_greek_merMod(model, return_variances)
   means_merMod <- create_means_merMod(rhs, fixed_greek_mermod, 
                                       model, ital_vars,
                                       use_coefs, coef_digits, 
@@ -662,10 +663,10 @@ convert_matrix <- function(mat) {
 
 create_l1_fixef <- function(model, ital_vars, use_coefs, coef_digits, 
                             mean_separate, fix_signs, wrap, terms_per_line, 
-                            operator_location) {
-  rhs <- extract_rhs(model)
+                            operator_location, return_variances) {
+  rhs <- extract_rhs(model, return_variances)
   lhs <- extract_lhs(model, ital_vars, use_coefs)
-  greek <- create_fixef_greek_merMod(model)
+  greek <- create_fixef_greek_merMod(model, return_variances)
   terms <- create_term(greek, ital_vars)
   
   terms <- vapply(terms, function(x) {
@@ -744,13 +745,14 @@ create_l1 <- function(model, ...) {
 create_l1.lmerMod <- function(model, mean_separate,
                              ital_vars, wrap, terms_per_line,
                              use_coefs, coef_digits, fix_signs,
-                             operator_location, sigma = "\\sigma^2") {
+                             operator_location, sigma = "\\sigma^2",
+                             return_variances) {
   
-  rhs <- extract_rhs(model)
+  rhs <- extract_rhs(model, return_variances)
   lhs <- extract_lhs(model, ital_vars, use_coefs)
   l1 <- create_l1_fixef(model, ital_vars, use_coefs, coef_digits, 
                         mean_separate, fix_signs, wrap, terms_per_line, 
-                        operator_location)
+                        operator_location, return_variances)
   if (is.null(mean_separate)) {
     mean_separate <- sum(rhs$l1) > 3
   }
@@ -767,13 +769,14 @@ create_l1.lmerMod <- function(model, mean_separate,
 create_l1.glmerMod <- function(model, mean_separate,
                               ital_vars, wrap, terms_per_line,
                               use_coefs, coef_digits, fix_signs,
-                              operator_location, sigma = "\\sigma^2") {
+                              operator_location, sigma = "\\sigma^2",
+                              return_variances) {
   
-  rhs <- extract_rhs(model)
+  rhs <- extract_rhs(model, return_variances)
   lhs <- extract_lhs(model, ital_vars, use_coefs)
   l1 <- create_l1_fixef(model, ital_vars, use_coefs, coef_digits, 
                         mean_separate, fix_signs, wrap, terms_per_line, 
-                        operator_location)
+                        operator_location, return_variances)
   
   combo <- paste0(which_family(model), "-", which_link(model))
   

--- a/man/extract_eq.Rd
+++ b/man/extract_eq.Rd
@@ -86,6 +86,11 @@ outcome ~ N(mu, sigma); mu = alpha + beta_1(wave). If \code{FALSE}, this
 same equation would be outcome ~ N(alpha + beta, sigma).}
 
 \item{...}{Additional arguments (for future development; not currently used).}
+
+\item{return_variances}{Logical. When \code{use_coefs = TRUE} with a mixed
+effects model (e.g., \code{lme4::lmer()}), should the variances and
+co-variances be returned? If \code{FALSE} (the default) standard deviations
+and correlations are returned instead.}
 }
 \value{
 A character of class \dQuote{equation}.

--- a/man/extract_eq.Rd
+++ b/man/extract_eq.Rd
@@ -20,6 +20,7 @@ extract_eq(
   fix_signs = TRUE,
   font_size,
   mean_separate,
+  return_variances = FALSE,
   ...
 )
 }
@@ -85,12 +86,12 @@ normal distribution? Defaults to \code{NULL}, in which case it will become
 outcome ~ N(mu, sigma); mu = alpha + beta_1(wave). If \code{FALSE}, this
 same equation would be outcome ~ N(alpha + beta, sigma).}
 
-\item{...}{Additional arguments (for future development; not currently used).}
-
 \item{return_variances}{Logical. When \code{use_coefs = TRUE} with a mixed
 effects model (e.g., \code{lme4::lmer()}), should the variances and
 co-variances be returned? If \code{FALSE} (the default) standard deviations
 and correlations are returned instead.}
+
+\item{...}{Additional arguments (for future development; not currently used).}
 }
 \value{
 A character of class \dQuote{equation}.

--- a/tests/testthat/_snaps/lmerMod.md
+++ b/tests/testthat/_snaps/lmerMod.md
@@ -1074,7 +1074,7 @@
 
     $$
     \begin{aligned}
-      \operatorname{score}_{i}  &\sim N \left(\alpha_{j[i],k[i],l[i]} + \beta_{1j[i],k[i],l[i]}(\operatorname{wave}), \sigma^2 \right) \\    
+      \operatorname{\widehat{score}}_{i}  &\sim N \left(96.8_{\alpha_{j[i],k[i],l[i]}} + 0.08_{\beta_{1j[i],k[i],l[i]}}(\operatorname{wave}), \sigma^2 \right) \\    
     \left(
       \begin{array}{c} 
         \begin{aligned}
@@ -1087,16 +1087,16 @@
     \left(
       \begin{array}{c} 
         \begin{aligned}
-          &\gamma_{0}^{\alpha} + \gamma_{1}^{\alpha}(\operatorname{group}_{\operatorname{low}}) + \gamma_{2}^{\alpha}(\operatorname{group}_{\operatorname{medium}}) + \gamma_{3l[i]}^{\alpha}(\operatorname{treatment}_{\operatorname{1}}) + \gamma_{4}^{\alpha}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) + \gamma_{5}^{\alpha}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}}) \\
-          &\gamma^{\beta_{1}}_{0} + \gamma^{\beta_{1}}_{1}(\operatorname{group}_{\operatorname{low}}) + \gamma^{\beta_{1}}_{2}(\operatorname{group}_{\operatorname{medium}}) + \gamma^{\beta_{1}}_{3}(\operatorname{treatment}_{\operatorname{1}}) + \gamma^{\beta_{1}}_{4}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) + \gamma^{\beta_{1}}_{5}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}})
+          &-7.71_{\gamma_{1}^{\alpha}}(\operatorname{group}_{\operatorname{low}}) - 5.63_{\gamma_{2}^{\alpha}}(\operatorname{group}_{\operatorname{medium}}) + 2.52_{\gamma_{3l[i]}^{\alpha}}(\operatorname{treatment}_{\operatorname{1}}) + 5.31_{\gamma_{4}^{\alpha}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) + 2.56_{\gamma_{5}^{\alpha}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}}) \\
+          &0.12_{\gamma^{\beta_{1}}_{1}}(\operatorname{group}_{\operatorname{low}}) + 0.38_{\gamma^{\beta_{1}}_{2}}(\operatorname{group}_{\operatorname{medium}}) - 0.01_{\gamma^{\beta_{1}}_{3}}(\operatorname{treatment}_{\operatorname{1}}) - 0.23_{\gamma^{\beta_{1}}_{4}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) - 0.52_{\gamma^{\beta_{1}}_{5}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}})
         \end{aligned}
       \end{array}
     \right)
     , 
     \left(
       \begin{array}{cc}
-         \sigma^2_{\alpha_{j}} & \rho_{\alpha_{j}\beta_{1j}} \\ 
-         \rho_{\beta_{1j}\alpha_{j}} & \sigma^2_{\beta_{1j}}
+         9.11 & -0.15 \\ 
+         -0.15 & 0.16
       \end{array}
     \right)
      \right)
@@ -1113,16 +1113,16 @@
     \left(
       \begin{array}{c} 
         \begin{aligned}
-          &\gamma_{0}^{\alpha} + \gamma_{1}^{\alpha}(\operatorname{prop\_low}) + \gamma_{2}^{\alpha}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}}) \\
-          &\gamma^{\beta_{1}}_{0} + \gamma^{\beta_{1}}_{1}(\operatorname{prop\_low}) + \gamma^{\beta_{1}}_{1}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}})
+          &19.01_{\gamma_{1}^{\alpha}}(\operatorname{prop\_low}) - 16.67_{\gamma_{2}^{\alpha}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}}) \\
+          &0.13_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low}) - 0.1_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}})
         \end{aligned}
       \end{array}
     \right)
     , 
     \left(
       \begin{array}{cc}
-         \sigma^2_{\alpha_{k}} & \rho_{\alpha_{k}\beta_{1k}} \\ 
-         \rho_{\beta_{1k}\alpha_{k}} & \sigma^2_{\beta_{1k}}
+         3.18 & 1 \\ 
+         1 & 0.01
       \end{array}
     \right)
      \right)
@@ -1140,18 +1140,107 @@
     \left(
       \begin{array}{c} 
         \begin{aligned}
-          &\mu_{\alpha_{l}} \\
-          &\mu_{\beta_{1l}} \\
-          &\mu_{\gamma_{3l}}
+          &0 \\
+          &0 \\
+          &0
         \end{aligned}
       \end{array}
     \right)
     , 
     \left(
       \begin{array}{ccc}
-         \sigma^2_{\alpha_{l}} & \rho_{\alpha_{l}\beta_{1l}} & \rho_{\alpha_{l}\gamma_{3l}} \\ 
-         \rho_{\beta_{1l}\alpha_{l}} & \sigma^2_{\beta_{1l}} & \rho_{\beta_{1l}\gamma_{3l}} \\ 
-         \rho_{\gamma_{3l}\alpha_{l}} & \rho_{\gamma_{3l}\beta_{1l}} & \sigma^2_{\gamma_{3l}}
+         1.12 & 1 & -0.64 \\ 
+         1 & 0.04 & -0.67 \\ 
+         -0.64 & -0.67 & 3.2
+      \end{array}
+    \right)
+     \right)
+        \text{, for district l = 1,} \dots \text{,L}
+    \end{aligned}
+    $$
+
+# return variances works
+
+    $$
+    \begin{aligned}
+      \operatorname{\widehat{score}}_{i}  &\sim N \left(96.8_{\alpha_{j[i],k[i],l[i]}} + 0.08_{\beta_{1j[i],k[i],l[i]}}(\operatorname{wave}), \sigma^2 \right) \\    
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &\alpha_{j} \\
+          &\beta_{1j}
+        \end{aligned}
+      \end{array}
+    \right)
+      &\sim N \left(
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &-7.71_{\gamma_{1}^{\alpha}}(\operatorname{group}_{\operatorname{low}}) - 5.63_{\gamma_{2}^{\alpha}}(\operatorname{group}_{\operatorname{medium}}) + 2.52_{\gamma_{3l[i]}^{\alpha}}(\operatorname{treatment}_{\operatorname{1}}) + 5.31_{\gamma_{4}^{\alpha}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) + 2.56_{\gamma_{5}^{\alpha}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}}) \\
+          &0.12_{\gamma^{\beta_{1}}_{1}}(\operatorname{group}_{\operatorname{low}}) + 0.38_{\gamma^{\beta_{1}}_{2}}(\operatorname{group}_{\operatorname{medium}}) - 0.01_{\gamma^{\beta_{1}}_{3}}(\operatorname{treatment}_{\operatorname{1}}) - 0.23_{\gamma^{\beta_{1}}_{4}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) - 0.52_{\gamma^{\beta_{1}}_{5}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}})
+        \end{aligned}
+      \end{array}
+    \right)
+    , 
+    \left(
+      \begin{array}{cc}
+         82.96 & -0.22 \\ 
+         -0.22 & 0.03
+      \end{array}
+    \right)
+     \right)
+        \text{, for sid j = 1,} \dots \text{,J} \\    
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &\alpha_{k} \\
+          &\beta_{1k}
+        \end{aligned}
+      \end{array}
+    \right)
+      &\sim N \left(
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &19.01_{\gamma_{1}^{\alpha}}(\operatorname{prop\_low}) - 16.67_{\gamma_{2}^{\alpha}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}}) \\
+          &0.13_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low}) - 0.1_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}})
+        \end{aligned}
+      \end{array}
+    \right)
+    , 
+    \left(
+      \begin{array}{cc}
+         10.11 & 0.03 \\ 
+         0.03 & 0
+      \end{array}
+    \right)
+     \right)
+        \text{, for school k = 1,} \dots \text{,K} \\    
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &\alpha_{l} \\
+          &\beta_{1l} \\
+          &\gamma_{3l}
+        \end{aligned}
+      \end{array}
+    \right)
+      &\sim N \left(
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &0 \\
+          &0 \\
+          &0
+        \end{aligned}
+      \end{array}
+    \right)
+    , 
+    \left(
+      \begin{array}{ccc}
+         1.25 & 0.04 & -2.29 \\ 
+         0.04 & 0 & -0.08 \\ 
+         -2.29 & -0.08 & 10.24
       \end{array}
     \right)
      \right)

--- a/tests/testthat/_snaps/lmerMod.md
+++ b/tests/testthat/_snaps/lmerMod.md
@@ -1074,7 +1074,7 @@
 
     $$
     \begin{aligned}
-      \operatorname{\widehat{score}}_{i}  &\sim N \left(96.8_{\alpha_{j[i],k[i],l[i]}} + 0.08_{\beta_{1j[i],k[i],l[i]}}(\operatorname{wave}), \sigma^2 \right) \\    
+      \operatorname{\widehat{score}}_{i}  &\sim N \left(98.18_{\alpha_{j[i],k[i],l[i]}} + 0.17_{\beta_{1j[i],k[i]}}(\operatorname{wave}), \sigma^2 \right) \\    
     \left(
       \begin{array}{c} 
         \begin{aligned}
@@ -1087,16 +1087,16 @@
     \left(
       \begin{array}{c} 
         \begin{aligned}
-          &-7.71_{\gamma_{1}^{\alpha}}(\operatorname{group}_{\operatorname{low}}) - 5.63_{\gamma_{2}^{\alpha}}(\operatorname{group}_{\operatorname{medium}}) + 2.52_{\gamma_{3l[i]}^{\alpha}}(\operatorname{treatment}_{\operatorname{1}}) + 5.31_{\gamma_{4}^{\alpha}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) + 2.56_{\gamma_{5}^{\alpha}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}}) \\
-          &0.12_{\gamma^{\beta_{1}}_{1}}(\operatorname{group}_{\operatorname{low}}) + 0.38_{\gamma^{\beta_{1}}_{2}}(\operatorname{group}_{\operatorname{medium}}) - 0.01_{\gamma^{\beta_{1}}_{3}}(\operatorname{treatment}_{\operatorname{1}}) - 0.23_{\gamma^{\beta_{1}}_{4}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) - 0.52_{\gamma^{\beta_{1}}_{5}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}})
+          &-2.1_{\gamma_{1}^{\alpha}}(\operatorname{treatment}_{\operatorname{1}}) \\
+          &0
         \end{aligned}
       \end{array}
     \right)
     , 
     \left(
       \begin{array}{cc}
-         9.11 & -0.15 \\ 
-         -0.15 & 0.16
+         9.26 & -0.2 \\ 
+         -0.2 & 0.29
       \end{array}
     \right)
      \right)
@@ -1113,34 +1113,6 @@
     \left(
       \begin{array}{c} 
         \begin{aligned}
-          &19.01_{\gamma_{1}^{\alpha}}(\operatorname{prop\_low}) - 16.67_{\gamma_{2}^{\alpha}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}}) \\
-          &0.13_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low}) - 0.1_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}})
-        \end{aligned}
-      \end{array}
-    \right)
-    , 
-    \left(
-      \begin{array}{cc}
-         3.18 & 1 \\ 
-         1 & 0.01
-      \end{array}
-    \right)
-     \right)
-        \text{, for school k = 1,} \dots \text{,K} \\    
-    \left(
-      \begin{array}{c} 
-        \begin{aligned}
-          &\alpha_{l} \\
-          &\beta_{1l} \\
-          &\gamma_{3l}
-        \end{aligned}
-      \end{array}
-    \right)
-      &\sim N \left(
-    \left(
-      \begin{array}{c} 
-        \begin{aligned}
-          &0 \\
           &0 \\
           &0
         \end{aligned}
@@ -1148,13 +1120,13 @@
     \right)
     , 
     \left(
-      \begin{array}{ccc}
-         1.12 & 1 & -0.64 \\ 
-         1 & 0.04 & -0.67 \\ 
-         -0.64 & -0.67 & 3.2
+      \begin{array}{cc}
+         3.24 & 1 \\ 
+         1 & 0.01
       \end{array}
     \right)
      \right)
+        \text{, for school k = 1,} \dots \text{,K} \\    \alpha_{l}  &\sim N \left(0, 0 \right)
         \text{, for district l = 1,} \dots \text{,L}
     \end{aligned}
     $$
@@ -1163,7 +1135,7 @@
 
     $$
     \begin{aligned}
-      \operatorname{\widehat{score}}_{i}  &\sim N \left(96.8_{\alpha_{j[i],k[i],l[i]}} + 0.08_{\beta_{1j[i],k[i],l[i]}}(\operatorname{wave}), \sigma^2 \right) \\    
+      \operatorname{\widehat{score}}_{i}  &\sim N \left(98.18_{\alpha_{j[i],k[i],l[i]}} + 0.17_{\beta_{1j[i],k[i]}}(\operatorname{wave}), \sigma^2 \right) \\    
     \left(
       \begin{array}{c} 
         \begin{aligned}
@@ -1176,16 +1148,16 @@
     \left(
       \begin{array}{c} 
         \begin{aligned}
-          &-7.71_{\gamma_{1}^{\alpha}}(\operatorname{group}_{\operatorname{low}}) - 5.63_{\gamma_{2}^{\alpha}}(\operatorname{group}_{\operatorname{medium}}) + 2.52_{\gamma_{3l[i]}^{\alpha}}(\operatorname{treatment}_{\operatorname{1}}) + 5.31_{\gamma_{4}^{\alpha}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) + 2.56_{\gamma_{5}^{\alpha}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}}) \\
-          &0.12_{\gamma^{\beta_{1}}_{1}}(\operatorname{group}_{\operatorname{low}}) + 0.38_{\gamma^{\beta_{1}}_{2}}(\operatorname{group}_{\operatorname{medium}}) - 0.01_{\gamma^{\beta_{1}}_{3}}(\operatorname{treatment}_{\operatorname{1}}) - 0.23_{\gamma^{\beta_{1}}_{4}}(\operatorname{group}_{\operatorname{low}} \times \operatorname{treatment}_{\operatorname{1}}) - 0.52_{\gamma^{\beta_{1}}_{5}}(\operatorname{group}_{\operatorname{medium}} \times \operatorname{treatment}_{\operatorname{1}})
+          &-2.1_{\gamma_{1}^{\alpha}}(\operatorname{treatment}_{\operatorname{1}}) \\
+          &0
         \end{aligned}
       \end{array}
     \right)
     , 
     \left(
       \begin{array}{cc}
-         82.96 & -0.22 \\ 
-         -0.22 & 0.03
+         85.78 & -0.53 \\ 
+         -0.53 & 0.09
       \end{array}
     \right)
      \right)
@@ -1202,34 +1174,6 @@
     \left(
       \begin{array}{c} 
         \begin{aligned}
-          &19.01_{\gamma_{1}^{\alpha}}(\operatorname{prop\_low}) - 16.67_{\gamma_{2}^{\alpha}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}}) \\
-          &0.13_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low}) - 0.1_{\gamma^{\beta_{1}}_{1}}(\operatorname{prop\_low} \times \operatorname{treatment}_{\operatorname{1}})
-        \end{aligned}
-      \end{array}
-    \right)
-    , 
-    \left(
-      \begin{array}{cc}
-         10.11 & 0.03 \\ 
-         0.03 & 0
-      \end{array}
-    \right)
-     \right)
-        \text{, for school k = 1,} \dots \text{,K} \\    
-    \left(
-      \begin{array}{c} 
-        \begin{aligned}
-          &\alpha_{l} \\
-          &\beta_{1l} \\
-          &\gamma_{3l}
-        \end{aligned}
-      \end{array}
-    \right)
-      &\sim N \left(
-    \left(
-      \begin{array}{c} 
-        \begin{aligned}
-          &0 \\
           &0 \\
           &0
         \end{aligned}
@@ -1237,13 +1181,13 @@
     \right)
     , 
     \left(
-      \begin{array}{ccc}
-         1.25 & 0.04 & -2.29 \\ 
-         0.04 & 0 & -0.08 \\ 
-         -2.29 & -0.08 & 10.24
+      \begin{array}{cc}
+         10.47 & 0.02 \\ 
+         0.02 & 0
       \end{array}
     \right)
      \right)
+        \text{, for school k = 1,} \dots \text{,K} \\    \alpha_{l}  &\sim N \left(0, 0 \right)
         \text{, for district l = 1,} \dots \text{,L}
     \end{aligned}
     $$

--- a/tests/testthat/test-glmerMod.R
+++ b/tests/testthat/test-glmerMod.R
@@ -14,7 +14,7 @@ test_that("Standard Poisson regression models work", {
   expect_snapshot_output(extract_eq(p1))
   
   
-  expect_warning(
+  suppressWarnings(
     p_complicated <- glmer(stops ~ eth*total_arrests + (eth|precinct), 
                            data = d,
                            family = poisson(link = "log"))
@@ -31,7 +31,7 @@ test_that("Poisson regression models with an offset work", {
   expect_snapshot_output(extract_eq(p_offset1))
   
   
-  expect_warning(
+  suppressWarnings(
     p_offset_complicated <- glmer(stops ~ eth*total_arrests + (eth|precinct), 
                            data = d,
                            family = poisson(link = "log"),

--- a/tests/testthat/test-lmerMod.R
+++ b/tests/testthat/test-lmerMod.R
@@ -268,5 +268,20 @@ test_that("use_coef works", {
     )
   )
   # Nested random effects 3
-  expect_snapshot_output(extract_eq(use_coef_m1))
+  expect_snapshot_output(extract_eq(use_coef_m1, use_coefs = TRUE))
+})
+
+test_that("return variances works", {
+  suppressWarnings(
+    use_coef_m1_var <- lmer(
+      score ~ wave * group * treatment + wave * prop_low * treatment +
+        (wave | sid) + (wave | school) +
+        (wave + treatment | district),
+      sim_longitudinal
+    )
+  )
+  # Nested random effects 3
+  expect_snapshot_output(
+    extract_eq(use_coef_m1_var, use_coefs = TRUE, return_variances = TRUE)
+  )
 })

--- a/tests/testthat/test-lmerMod.R
+++ b/tests/testthat/test-lmerMod.R
@@ -261,9 +261,9 @@ test_that("Nested model syntax works", {
 test_that("use_coef works", {
   suppressWarnings(
     use_coef_m1 <- lmer(
-      score ~ wave * group * treatment + wave * prop_low * treatment +
+      score ~ wave  + treatment +
         (wave | sid) + (wave | school) +
-        (wave + treatment | district),
+        (1 | district),
       sim_longitudinal
     )
   )
@@ -274,9 +274,9 @@ test_that("use_coef works", {
 test_that("return variances works", {
   suppressWarnings(
     use_coef_m1_var <- lmer(
-      score ~ wave * group * treatment + wave * prop_low * treatment +
+      score ~ wave  + treatment +
         (wave | sid) + (wave | school) +
-        (wave + treatment | district),
+        (1 | district),
       sim_longitudinal
     )
   )


### PR DESCRIPTION
By default, we return the SDs and Cors for mixed effects models. This makes it so users can request the variances and covariances instead.

``` r
m <- lme4::glmer(stops ~ eth + (eth|precinct), 
                 data = equatiomatic::arrests,
                 family = poisson(link = "log"))
equatiomatic::extract_eq(m, use_coef = TRUE)
#> NULL
```

<img src="https://i.imgur.com/cKOKOy2.png" width="1515" />

``` r
equatiomatic::extract_eq(m, use_coef = TRUE, return_variances = TRUE)
```

<img src="https://i.imgur.com/iWPvUXZ.png" width="1515" />

``` r
as.data.frame(lme4::VarCorr(m))
#>        grp        var1        var2       vcov      sdcor
#> 1 precinct (Intercept)        <NA>  0.9820173  0.9909679
#> 2 precinct ethhispanic        <NA>  1.7782045  1.3334934
#> 3 precinct    ethwhite        <NA>  3.2340895  1.7983574
#> 4 precinct (Intercept) ethhispanic -0.8416862 -0.6369419
#> 5 precinct (Intercept)    ethwhite -1.4090190 -0.7906445
#> 6 precinct ethhispanic    ethwhite  1.6813204  0.7011059
```

<sup>Created on 2021-05-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>