### PR TITLE
Add new function to make sure IDs are explicit

### DIFF
--- a/R/extract_rhs.R
+++ b/R/extract_rhs.R
@@ -435,7 +435,7 @@ collapse_list <- function(x, y) {
 detect_group_coef <- function(model, rhs) {
   outcome <- all.vars(formula(model))[1]
   d <- model@frame
-
+  
   random_lev_names <- names(extract_random_vars(rhs))
   random_levs <- unlist(strsplit(random_lev_names, ":"))
   random_levs <- gsub("^\\(|\\)$", "", random_levs)
@@ -448,6 +448,9 @@ detect_group_coef <- function(model, rhs) {
   ranef_order <- rev(sort(ranef_order))
   random_lev_ids <- random_lev_ids[, names(ranef_order), drop = FALSE]
 
+  # Make sure there are explicit ids
+  random_lev_ids <- make_explicit_id(random_lev_ids)
+  
   X <- d[!(names(d) %in% c(random_levs, outcome))]
 
   lev_assign <- vector("list", length(random_levs))
@@ -464,10 +467,22 @@ detect_group_coef <- function(model, rhs) {
   unlist(out[!is.na(out)])
 }
 
+row_paste <- function(d) {
+  apply(d, 1, paste, collapse = "-")
+}
 
+#' Makes the grouping variables explicit, which is neccessary for
+#' detecting group-level predictors
+#' @param ranef_df A data frame that includes only the random 
+#'   effect ID variables (i.e., random_lev_ids)
+#' @noRd
 
-
-
+make_explicit_id <- function(ranef_df) {
+  for(i in seq_along(ranef_df)[-length(ranef_df)]) {
+    ranef_df[[i]] <- row_paste(ranef_df[ ,i:length(ranef_df)])
+  }
+  ranef_df
+}
 
 
 #' Extract the primary terms from all terms

--- a/tests/testthat/_snaps/lmerMod.md
+++ b/tests/testthat/_snaps/lmerMod.md
@@ -1,3 +1,22 @@
+# Implicit ID variables are handled
+
+    Linear mixed model fit by REML ['lmerMod']
+    Formula: score ~ wave + treatment + (wave | sid) + (wave | school)
+       Data: d
+    REML criterion at convergence: 7123.501
+    Random effects:
+     Groups   Name        Std.Dev.  Corr
+     school   (Intercept) 4.6561228     
+              wave        0.0044121 1.00
+     sid      (Intercept) 1.8160871     
+              wave        0.0003033 1.00
+     Residual             8.2892514     
+    Number of obs: 1000, groups:  school, 15; sid, 7
+    Fixed Effects:
+    (Intercept)         wave   treatment1  
+        97.9930       0.1735      -1.6958  
+    optimizer (nloptwrap) convergence code: 0 (OK) ; 0 optimizer warnings; 1 lme4 warnings 
+
 # Renaming Variables works
 
     $$

--- a/tests/testthat/_snaps/lmerMod.md
+++ b/tests/testthat/_snaps/lmerMod.md
@@ -1,21 +1,62 @@
 # Implicit ID variables are handled
 
-    Linear mixed model fit by REML ['lmerMod']
-    Formula: score ~ wave + treatment + (wave | sid) + (wave | school)
-       Data: d
-    REML criterion at convergence: 7123.501
-    Random effects:
-     Groups   Name        Std.Dev.  Corr
-     school   (Intercept) 4.6561228     
-              wave        0.0044121 1.00
-     sid      (Intercept) 1.8160871     
-              wave        0.0003033 1.00
-     Residual             8.2892514     
-    Number of obs: 1000, groups:  school, 15; sid, 7
-    Fixed Effects:
-    (Intercept)         wave   treatment1  
-        97.9930       0.1735      -1.6958  
-    optimizer (nloptwrap) convergence code: 0 (OK) ; 0 optimizer warnings; 1 lme4 warnings 
+    $$
+    \begin{aligned}
+      \operatorname{score}_{i}  &\sim N \left(\alpha_{j[i],k[i]} + \beta_{1j[i],k[i]}(\operatorname{wave}), \sigma^2 \right) \\    
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &\alpha_{j} \\
+          &\beta_{1j}
+        \end{aligned}
+      \end{array}
+    \right)
+      &\sim N \left(
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &\gamma_{0}^{\alpha} + \gamma_{1}^{\alpha}(\operatorname{treatment}_{\operatorname{1}}) \\
+          &\mu_{\beta_{1j}}
+        \end{aligned}
+      \end{array}
+    \right)
+    , 
+    \left(
+      \begin{array}{cc}
+         \sigma^2_{\alpha_{j}} & \rho_{\alpha_{j}\beta_{1j}} \\ 
+         \rho_{\beta_{1j}\alpha_{j}} & \sigma^2_{\beta_{1j}}
+      \end{array}
+    \right)
+     \right)
+        \text{, for school j = 1,} \dots \text{,J} \\    
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &\alpha_{k} \\
+          &\beta_{1k}
+        \end{aligned}
+      \end{array}
+    \right)
+      &\sim N \left(
+    \left(
+      \begin{array}{c} 
+        \begin{aligned}
+          &\mu_{\alpha_{k}} \\
+          &\mu_{\beta_{1k}}
+        \end{aligned}
+      \end{array}
+    \right)
+    , 
+    \left(
+      \begin{array}{cc}
+         \sigma^2_{\alpha_{k}} & \rho_{\alpha_{k}\beta_{1k}} \\ 
+         \rho_{\beta_{1k}\alpha_{k}} & \sigma^2_{\beta_{1k}}
+      \end{array}
+    \right)
+     \right)
+        \text{, for sid k = 1,} \dots \text{,K}
+    \end{aligned}
+    $$
 
 # Renaming Variables works
 

--- a/tests/testthat/test-lmerMod.R
+++ b/tests/testthat/test-lmerMod.R
@@ -1,4 +1,22 @@
 library(lme4)
+test_that("Implicit ID variables are handled", {
+  splt <- split(sim_longitudinal, sim_longitudinal$school)
+  splt <- lapply(splt, function(x) {
+    x$sid <- as.numeric(as.factor(x$sid))
+    x
+  })
+  d <- do.call(rbind, splt)
+  
+  m <- lme4::lmer(
+    score ~ wave + treatment +
+      (wave | sid) + (wave | school),
+    data = d
+  )
+  
+  expect_snapshot_output(m)
+  
+})
+
 
 test_that("Renaming Variables works", {
   m5 <- lme4::lmer(

--- a/tests/testthat/test-lmerMod.R
+++ b/tests/testthat/test-lmerMod.R
@@ -13,7 +13,7 @@ test_that("Implicit ID variables are handled", {
     data = d
   )
   
-  expect_snapshot_output(m)
+  expect_snapshot_output(extract_eq(m))
   
 })
 


### PR DESCRIPTION
This fixes #166.

``` r
library(equatiomatic)

d <- readr::read_csv("http://alexanderdemos.org/Mixed/Sim3level.csv")
#> 
#> ── Column specification ────────────────────────────────────────────────────────
#> cols(
#>   Math = col_double(),
#>   ActiveTime = col_double(),
#>   ClassSize = col_double(),
#>   Classroom = col_double(),
#>   School = col_character(),
#>   StudentID = col_double()
#> )

m1 <- lme4::lmer(Math ~ ActiveTime + ClassSize + 
                  (1|Classroom) + (1|School),
                data = d)

extract_eq(m1)
```

<img src="https://i.imgur.com/GMdfVYU.png" width="1269" />

``` r
# make a second example with implicit IDs

splt <- split(sim_longitudinal, sim_longitudinal$school)
  splt <- lapply(splt, function(x) {
    x$sid <- as.numeric(as.factor(x$sid))
    x
  })
d <- do.call(rbind, splt)

m2 <- lme4::lmer(
  score ~ wave + treatment +
    (wave | sid) + (wave | school),
  data = d
)
#> boundary (singular) fit: see ?isSingular

extract_eq(m2)
```

<img src="https://i.imgur.com/B7pm0bh.png" width="1515" />

<sup>Created on 2021-08-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>