### PR TITLE
Add error message for merMods w/mismatched fixed/rand

### DIFF
--- a/man/extract_eq.Rd
+++ b/man/extract_eq.Rd
@@ -152,7 +152,7 @@ A character of class \dQuote{equation}.
 \details{
 Extract the variable names from a model to produce a 'LaTeX' equation, which is
 output to the screen. Supports any model supported by
-\link[broom:tidy]{broom::tidy}.
+\link[broom:reexports]{broom::tidy}.
 }
 \examples{
 # Simple model

--- a/tests/testthat/test-glmerMod.R
+++ b/tests/testthat/test-glmerMod.R
@@ -1,5 +1,12 @@
 library(lme4)
 
+test_that("Checking for random/fixed effects works", {
+  m <- glmer(bush ~ 1 + edu + (black|state),
+             data = polls,
+             family = binomial(link = "logit"))
+  expect_error(extract_eq(m))
+})
+
 d <- arrests
 totes <- tapply(d$arrests, d$precinct, sum)
 tot_arrests <- data.frame(precinct = as.numeric(names(totes)),

--- a/tests/testthat/test-lmerMod.R
+++ b/tests/testthat/test-lmerMod.R
@@ -1,5 +1,10 @@
 library(lme4)
 
+test_that("Checking for random/fixed effects works", {
+  m <- lmer(score ~ wave + (group | sid), data = sim_longitudinal)
+  expect_error(extract_eq(m))
+})
+
 test_that("colorizing works", {
   # calculate district means
   dist_mean <- tapply(


### PR DESCRIPTION
This addresses #195 with a better error message when a model is specified with a random effect without a corresponding fixed effect.

``` r
library(equatiomatic)
library(lme4)
#> Loading required package: Matrix

m <- glmer(bush ~ 0 + edu + (black|state),
           data = polls,
           family = binomial(link = "logit"))
extract_eq(m)
#> Error: {equatiomatic} only supports models where each random effect has a corresponding fixed effect. 
#> You specified the following variables as randomly varying without including the corresponding fixed effect: (Intercept), black
```

<sup>Created on 2021-09-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>