### PR TITLE
Fix subscripts when intercept is dropped

### DIFF
--- a/R/create_eq.R
+++ b/R/create_eq.R
@@ -716,12 +716,18 @@ add_greek.default <- function(rhs, terms, greek = "beta", intercept = "alpha",
   if (raw_tex & !(intercept %in% c("alpha", "beta"))) {
     int <- intercept
   }
-
+  
+  indices <- if ("(Intercept)" %in% rhs$term) {
+    seq_len(nrow(rhs)) - 1
+  } else {
+    seq_len(nrow(rhs))
+  } 
+  
   ifelse(rhs$term == "(Intercept)",
     colorize(greek_colors[1], int),
     anno_greek(
       greek, 
-      seq_len(nrow(rhs)) - 1, 
+      indices, 
       terms, 
       greek_colors, 
       subscript_colors, 

--- a/man/extract_eq.Rd
+++ b/man/extract_eq.Rd
@@ -152,7 +152,7 @@ A character of class \dQuote{equation}.
 \details{
 Extract the variable names from a model to produce a 'LaTeX' equation, which is
 output to the screen. Supports any model supported by
-\link[broom:tidy]{broom::tidy}.
+\link[broom:reexports]{broom::tidy}.
 }
 \examples{
 # Simple model

--- a/tests/testthat/_snaps/lm.md
+++ b/tests/testthat/_snaps/lm.md
@@ -1,3 +1,9 @@
+# Dropping intercept notation works
+
+    $$
+    \operatorname{bill\_depth\_mm} = \beta_{1}(\operatorname{flipper\_length\_mm}) + \beta_{2}(\operatorname{island}_{\operatorname{Biscoe}}) + \beta_{3}(\operatorname{island}_{\operatorname{Dream}}) + \beta_{4}(\operatorname{island}_{\operatorname{Torgersen}}) + \beta_{5}(\operatorname{flipper\_length\_mm} \times \operatorname{island}_{\operatorname{Dream}}) + \beta_{6}(\operatorname{flipper\_length\_mm} \times \operatorname{island}_{\operatorname{Torgersen}}) + \epsilon
+    $$
+
 # colorizing works
 
     $$

--- a/tests/testthat/test-lm.R
+++ b/tests/testthat/test-lm.R
@@ -1,3 +1,8 @@
+test_that("Dropping intercept notation works", {
+  m <- lm(bill_depth_mm ~ 0 + flipper_length_mm*island, penguins)
+  expect_snapshot_output(extract_eq(m))
+})
+
 test_that("colorizing works", {
   m <- lm(bill_depth_mm ~ flipper_length_mm*island, penguins)
   


### PR DESCRIPTION
Previously, when the intercept was dropped, the first coefficient would be listed as `"\\beta_{0}"`, rather than `"\\beta_{1}"`. That is fixed with this PR.

``` r
library(equatiomatic)
m <- lm(bill_depth_mm ~ 0 + flipper_length_mm*island, penguins)
extract_eq(m)
```

<img src="https://i.imgur.com/ySKlFe7.png" width="1515" />

<sup>Created on 2021-09-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>