### PR TITLE
Remotes to yonicd/texPreview eliminated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,5 +90,3 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3
 Config/testthat/parallel: true
-Remotes:
-    yonicd/texPreview


### PR DESCRIPTION
The right version of texPreview is on CRAN (needs >= 2.0.0 and CRAN version is 2.1.0). So, no need of a Remotes entry in DESCRIPTION any more.