### PR TITLE
Don't use expression as ggplot label aesthetic

### DIFF
--- a/vignettes/plotting-integration.Rmd
+++ b/vignettes/plotting-integration.Rmd
@@ -84,8 +84,8 @@ ggplot(penguins, aes(x = bill_length_mm, y = body_mass_g)) +
   geom_point() +
   geom_smooth(method = "lm", color = "#ab00fa") +
   annotate("text",
-    label = TeX(prep_eq), x = 35, y = 2500, hjust = 0,
-    color = "#ab00fa"
+    label = as.character(TeX(prep_eq)), x = 35, y = 2500, hjust = 0,
+    color = "#ab00fa", parse = TRUE
   ) +
   labs(title = "Relation between bill length and body mass") +
   ylim(2000, 6500)


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue we found is that an expression was used as the `label` aesthetic, which until recently worked by accident.
ggplot2 now more strictly requires that aesthetics are vectors, which expressions are not.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
