### PR TITLE
extract_lhs.summary.lm() : a method for summary.lm object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: equatiomatic
 Title: Transform Models into 'LaTeX' Equations
-Version: 0.3.6
+Version: 0.3.7
 Authors@R:
     c(person(given = "Daniel",
              family = "Anderson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# equatiomatic 0.3.7
+* Extracts equations for `summary.lm`.
+
 # equatiomatic 0.3.6
 * Correction of the Authors@R field in the DESCRIPTION file (required by CRAN).
 

--- a/R/extract_lhs.R
+++ b/R/extract_lhs.R
@@ -10,7 +10,7 @@ extract_lhs <- function(model, ...) {
   UseMethod("extract_lhs", model)
 }
 
-#' Extract left-hand side of an lm object
+#' Extract left-hand side of an lm object object
 #'
 #' Extract a string of the outcome/dependent/y variable of a model
 #'
@@ -42,6 +42,19 @@ extract_lhs.lm <- function(model, ital_vars, show_distribution, use_coefs,
   lhs_escaped <- add_tex_ital_v(lhs_escaped, ital_vars)
   colorize_terms(var_colors, list(lhs), list(lhs_escaped))
 }
+
+#' Extract left-hand side of an summary.lm object object
+#'
+#' Extract a string of the outcome/dependent/y variable of a model
+#'
+#' @keywords internal
+#'
+#' @inheritParams extract_eq
+#'
+#' @return A character string
+#' @noRd
+
+extract_lhs.summary.lm <- extract_lhs.lm
 
 #' Extract left-hand side of an lme4::lmer object
 #'

--- a/R/extract_lhs.R
+++ b/R/extract_lhs.R
@@ -43,7 +43,7 @@ extract_lhs.lm <- function(model, ital_vars, show_distribution, use_coefs,
   colorize_terms(var_colors, list(lhs), list(lhs_escaped))
 }
 
-#' Extract left-hand side of an summary.lm object object
+#' Extract left-hand side of an summary.lm object
 #'
 #' Extract a string of the outcome/dependent/y variable of a model
 #'


### PR DESCRIPTION
Hello,

There is no method for `summary.lm` objects. The code needed to extract the equation is exactly the same as for `lm` objects. I therefore propose adding a new method for the function `extract_lhs()`: `extract_lhs.summary.lm()`.

Have a nice day,